### PR TITLE
feat: add debug mode support with debugpy

### DIFF
--- a/template/netwrix-python/index.py
+++ b/template/netwrix-python/index.py
@@ -381,4 +381,12 @@ def call_handler(path):
     return resp
 
 if __name__ == '__main__':
-    serve(app, host='0.0.0.0', port=5000)
+
+    if os.getenv('DEBUG_MODE', 'false').lower() == 'true':
+        import debugpy
+
+        debugpy.listen(5678)
+        debugpy.wait_for_client()
+        app.run(host='0.0.0.0', port=5000, debug=True, use_debugger=False)
+    else:
+        serve(app, host='0.0.0.0', port=5000)

--- a/template/netwrix-python/requirements.txt
+++ b/template/netwrix-python/requirements.txt
@@ -2,3 +2,5 @@ flask
 waitress
 tox==3.*
 requests==2.31.0
+
+debugpy


### PR DESCRIPTION
Add support for remote debugging using debugpy when DEBUG_MODE environment variable is set to true. This allows for easier development and troubleshooting of the connector.

- Add debugpy dependency
- Implement conditional debug mode execution
- Configure debug server on port 5678