### PR TITLE
Align C# connector template with Python reference

### DIFF
--- a/dspm-connector-templates.sln
+++ b/dspm-connector-templates.sln
@@ -1,0 +1,49 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+ VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "template", "template", "{B81DD640-40B3-2EBF-4088-4A2CAF1F9B56}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "netwrix-internal-csharp", "netwrix-internal-csharp", "{B8F5D157-D4AA-BF43-FE1B-98E1200182E1}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "netwrix-csharp", "netwrix-csharp", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConnectorFramework", "template\netwrix-csharp\ConnectorFramework\ConnectorFramework.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConnectorFramework.Tests", "template\netwrix-csharp\ConnectorFramework.Tests\ConnectorFramework.Tests.csproj", "{22222222-2222-2222-2222-222222222222}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Function", "template\netwrix-csharp\function\Function.csproj", "{33333333-3333-3333-3333-333333333333}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890} = {B81DD640-40B3-2EBF-4088-4A2CAF1F9B56}
+		{11111111-1111-1111-1111-111111111111} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+		{22222222-2222-2222-2222-222222222222} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+		{33333333-3333-3333-3333-333333333333} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = preSolution
+		SolutionGuid = {74B15D14-ADF1-4D2B-8689-CE243F32FA2D}
+	EndGlobalSection
+EndGlobal

--- a/template/netwrix-csharp/.editorconfig
+++ b/template/netwrix-csharp/.editorconfig
@@ -464,6 +464,11 @@ dotnet_diagnostic.IDE0161.severity = silent
 dotnet_diagnostic.IDE0005.severity = silent
 
 
+# Template function stub — suppress unused-parameter warnings so the signature
+# remains readable for implementors who will fill in the body.
+[function/**.cs]
+dotnet_diagnostic.IDE0060.severity = none
+
 # Verify settings
 [*.{received,verified}.{txt,xml,json}]
 charset = "utf-8-bom"

--- a/template/netwrix-csharp/ConnectorFramework.Tests/AACorePlatformFacadeTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/AACorePlatformFacadeTests.cs
@@ -1,0 +1,161 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Netwrix.Overlord.Sdk.Cloud.TaskScheduler.Models;
+using Netwrix.Overlord.Sdk.Core.Activity.Models;
+using Netwrix.Overlord.Sdk.Core.State.Models;
+using Xunit;
+
+namespace Netwrix.ConnectorFramework.Tests;
+
+public class AACorePlatformFacadeTests
+{
+    private static AACorePlatformFacade CreateFacade(IScanWriter writer)
+        => new(NullLogger<AACorePlatformFacade>.Instance, writer);
+
+    private static Mock<IScanWriter> WriterMock()
+    {
+        var mock = new Mock<IScanWriter>();
+        mock.Setup(w => w.FlushTablesAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        return mock;
+    }
+
+    // ── UploadSiTRecords ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UploadSiTRecords_SavesEachObjectToObjectsTable()
+    {
+        var writerMock = WriterMock();
+        var facade = CreateFacade(writerMock.Object);
+        var models = new List<SitObjectImportModel>
+        {
+            new() { Id = Guid.NewGuid().ToString(), Type = Guid.NewGuid() },
+            new() { Id = Guid.NewGuid().ToString(), Type = Guid.NewGuid() },
+        };
+
+        await facade.UploadSiTRecords(new CrawlContext(), models, [], [], isFinal: false);
+
+        writerMock.Verify(w => w.SaveObject("objects", models[0], true), Times.Once);
+        writerMock.Verify(w => w.SaveObject("objects", models[1], true), Times.Once);
+    }
+
+    [Fact]
+    public async Task UploadSiTRecords_WhenIsFinalFalse_DoesNotFlush()
+    {
+        var writerMock = WriterMock();
+        var facade = CreateFacade(writerMock.Object);
+
+        await facade.UploadSiTRecords(new CrawlContext(), [], [], [], isFinal: false);
+
+        writerMock.Verify(w => w.FlushTablesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UploadSiTRecords_WhenIsFinalTrue_FlushesWriter()
+    {
+        var writerMock = WriterMock();
+        var facade = CreateFacade(writerMock.Object);
+
+        await facade.UploadSiTRecords(new CrawlContext(), [], [], [], isFinal: true);
+
+        writerMock.Verify(w => w.FlushTablesAsync(CancellationToken.None), Times.Once);
+    }
+
+    // ── UploadSiTSchemaRecords ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UploadSiTSchemaRecords_SavesEachEntityToNamedTable()
+    {
+        var writerMock = WriterMock();
+        var facade = CreateFacade(writerMock.Object);
+        var entities = new List<JsonObject> { new JsonObject(), new JsonObject() };
+
+        await facade.UploadSiTSchemaRecords(new CrawlContext(), "schema_table", entities, isFinal: false);
+
+        writerMock.Verify(w => w.SaveObject("schema_table", It.IsAny<JsonObject>(), true), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task UploadSiTSchemaRecords_WhenIsFinalFalse_DoesNotFlush()
+    {
+        var writerMock = WriterMock();
+        var facade = CreateFacade(writerMock.Object);
+
+        await facade.UploadSiTSchemaRecords(new CrawlContext(), "schema_table", [], isFinal: false);
+
+        writerMock.Verify(w => w.FlushTablesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UploadSiTSchemaRecords_WhenIsFinalTrue_FlushesWriter()
+    {
+        var writerMock = WriterMock();
+        var facade = CreateFacade(writerMock.Object);
+
+        await facade.UploadSiTSchemaRecords(new CrawlContext(), "schema_table", [], isFinal: true);
+
+        writerMock.Verify(w => w.FlushTablesAsync(CancellationToken.None), Times.Once);
+    }
+
+    // ── UploadActivityRecords ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UploadActivityRecords_SavesEachRecordToActivityRecordsTable()
+    {
+        var writerMock = WriterMock();
+        var facade = CreateFacade(writerMock.Object);
+        var records = new List<ActivityRecord> { new(), new() };
+
+        await facade.UploadActivityRecords(records);
+
+        writerMock.Verify(w => w.SaveObject("activity_records", It.IsAny<ActivityRecord>(), true), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task UploadActivityRecords_NeverFlushesWriter()
+    {
+        var writerMock = WriterMock();
+        var facade = CreateFacade(writerMock.Object);
+
+        await facade.UploadActivityRecords(new List<ActivityRecord> { new() });
+
+        writerMock.Verify(w => w.FlushTablesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ── DecryptData ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DecryptData_DeserializesJsonPayload()
+    {
+        var facade = CreateFacade(WriterMock().Object);
+        var payload = JsonSerializer.SerializeToUtf8Bytes(new { name = "Alice" });
+
+        var result = await facade.DecryptData<JsonElement>(Array.Empty<byte>(), payload);
+
+        Assert.Equal("Alice", result.GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public async Task DecryptTenancyData_DeserializesJsonPayload()
+    {
+        var facade = CreateFacade(WriterMock().Object);
+        var payload = JsonSerializer.SerializeToUtf8Bytes(new { tenantId = "t-1" });
+
+        var result = await facade.DecryptTenancyData<JsonElement>(Array.Empty<byte>(), payload);
+
+        Assert.Equal("t-1", result.GetProperty("tenantId").GetString());
+    }
+
+    // ── DecryptServiceBusMessage ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task DecryptServiceBusMessage_ThrowsNotSupportedException()
+    {
+        var facade = CreateFacade(WriterMock().Object);
+
+        await Assert.ThrowsAsync<NotSupportedException>(() =>
+            facade.DecryptServiceBusMessage<object>("msg"));
+    }
+}

--- a/template/netwrix-csharp/ConnectorFramework.Tests/AACorePlatformFacadeTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/AACorePlatformFacadeTests.cs
@@ -25,42 +25,12 @@ public class AACorePlatformFacadeTests
     // ── UploadSiTRecords ──────────────────────────────────────────────────────
 
     [Fact]
-    public async Task UploadSiTRecords_SavesEachObjectToObjectsTable()
+    public async Task UploadSiTRecords_ThrowsNotSupportedException()
     {
-        var writerMock = WriterMock();
-        var facade = CreateFacade(writerMock.Object);
-        var models = new List<SitObjectImportModel>
-        {
-            new() { Id = Guid.NewGuid().ToString(), Type = Guid.NewGuid() },
-            new() { Id = Guid.NewGuid().ToString(), Type = Guid.NewGuid() },
-        };
+        var facade = CreateFacade(WriterMock().Object);
 
-        await facade.UploadSiTRecords(new CrawlContext(), models, [], [], isFinal: false);
-
-        writerMock.Verify(w => w.SaveObject("objects", models[0], true), Times.Once);
-        writerMock.Verify(w => w.SaveObject("objects", models[1], true), Times.Once);
-    }
-
-    [Fact]
-    public async Task UploadSiTRecords_WhenIsFinalFalse_DoesNotFlush()
-    {
-        var writerMock = WriterMock();
-        var facade = CreateFacade(writerMock.Object);
-
-        await facade.UploadSiTRecords(new CrawlContext(), [], [], [], isFinal: false);
-
-        writerMock.Verify(w => w.FlushTablesAsync(It.IsAny<CancellationToken>()), Times.Never);
-    }
-
-    [Fact]
-    public async Task UploadSiTRecords_WhenIsFinalTrue_FlushesWriter()
-    {
-        var writerMock = WriterMock();
-        var facade = CreateFacade(writerMock.Object);
-
-        await facade.UploadSiTRecords(new CrawlContext(), [], [], [], isFinal: true);
-
-        writerMock.Verify(w => w.FlushTablesAsync(CancellationToken.None), Times.Once);
+        await Assert.ThrowsAsync<NotSupportedException>(() =>
+            facade.UploadSiTRecords(new CrawlContext(), [], [], [], isFinal: false));
     }
 
     // ── UploadSiTSchemaRecords ────────────────────────────────────────────────
@@ -102,15 +72,14 @@ public class AACorePlatformFacadeTests
     // ── UploadActivityRecords ────────────────────────────────────────────────
 
     [Fact]
-    public async Task UploadActivityRecords_SavesEachRecordToActivityRecordsTable()
+    public async Task UploadActivityRecords_IsNoOp_UntilTableExists()
     {
         var writerMock = WriterMock();
         var facade = CreateFacade(writerMock.Object);
-        var records = new List<ActivityRecord> { new(), new() };
 
-        await facade.UploadActivityRecords(records);
+        await facade.UploadActivityRecords(new List<ActivityRecord> { new(), new() });
 
-        writerMock.Verify(w => w.SaveObject("activity_records", It.IsAny<ActivityRecord>(), true), Times.Exactly(2));
+        writerMock.Verify(w => w.SaveObject(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<bool>()), Times.Never);
     }
 
     [Fact]

--- a/template/netwrix-csharp/ConnectorFramework.Tests/AACrawlTaskCorePlatformFacadeTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/AACrawlTaskCorePlatformFacadeTests.cs
@@ -1,0 +1,198 @@
+using System.Diagnostics;
+using System.Reflection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Netwrix.Overlord.Sdk.Cloud.TaskScheduler.Models;
+using Netwrix.Overlord.Sdk.Core.Activity.Models;
+using Xunit;
+
+namespace Netwrix.ConnectorFramework.Tests;
+
+public class AACrawlTaskCorePlatformFacadeTests
+{
+    private static Mock<IScanWriter> WriterMock()
+    {
+        var mock = new Mock<IScanWriter>();
+        mock.Setup(w => w.FlushTablesAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        return mock;
+    }
+
+    private static Mock<IScanProgress> ProgressMock()
+    {
+        var mock = new Mock<IScanProgress>();
+        mock.Setup(p => p.Execution).Returns(new ExecutionContext(ScanId: null, ScanExecutionId: "exec-test", SourceId: null, SourceType: null, SourceVersion: null, FunctionType: null));
+        mock.Setup(p => p.StartActivity(It.IsAny<string>())).Returns((Activity?)null);
+        mock.Setup(p => p.UpdateExecutionAsync(
+                It.IsAny<string?>(),
+                It.IsAny<int?>(),
+                It.IsAny<int?>(),
+                It.IsAny<DateTimeOffset?>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        return mock;
+    }
+
+    private static AACorePlatformFacade CreateCore(IScanWriter? writer = null)
+        => new(NullLogger<AACorePlatformFacade>.Instance, writer ?? WriterMock().Object);
+
+    private static AACrawlTaskCorePlatformFacade CreateFacade(
+        AACorePlatformFacade? core = null,
+        IScanProgress? progress = null)
+        => new(
+            core ?? CreateCore(),
+            progress ?? ProgressMock().Object,
+            NullLogger<AACrawlTaskCorePlatformFacade>.Instance);
+
+    /// <summary>
+    /// Sets _lastUpdateTimestamp to a value that makes GetElapsedTime report > 5 minutes,
+    /// so EnsureRegularTaskProgressUpdate will not be throttled.
+    /// </summary>
+    private static void SimulateElapsedMinutes(AACrawlTaskCorePlatformFacade facade, double minutes)
+    {
+        var field = typeof(AACrawlTaskCorePlatformFacade)
+            .GetField("_lastUpdateTimestamp", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var pastTimestamp = Stopwatch.GetTimestamp() - (long)(minutes * 60 * Stopwatch.Frequency);
+        field.SetValue(facade, pastTimestamp);
+    }
+
+    // ── EnsureRegularTaskProgressUpdate ───────────────────────────────────────
+
+    [Fact]
+    public async Task EnsureRegularTaskProgressUpdate_BelowThreshold_DoesNotCallUpdateExecution()
+    {
+        var progressMock = ProgressMock();
+        var facade = CreateFacade(progress: progressMock.Object);
+        // Default _lastUpdateTimestamp is Stopwatch.GetTimestamp() — elapsed is ~0 minutes
+
+        await facade.EnsureRegularTaskProgressUpdate(Guid.NewGuid(), new CrawlResponse { ProcessedItemCount = 10 });
+
+        progressMock.Verify(p => p.UpdateExecutionAsync(
+            It.IsAny<string?>(),
+            It.IsAny<int?>(),
+            It.IsAny<int?>(),
+            It.IsAny<DateTimeOffset?>(),
+            It.IsAny<int>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task EnsureRegularTaskProgressUpdate_AboveThreshold_CallsUpdateExecution()
+    {
+        var progressMock = ProgressMock();
+        var facade = CreateFacade(progress: progressMock.Object);
+        SimulateElapsedMinutes(facade, 6); // > 5 minutes
+
+        await facade.EnsureRegularTaskProgressUpdate(Guid.NewGuid(), new CrawlResponse { ProcessedItemCount = 10 });
+
+        progressMock.Verify(p => p.UpdateExecutionAsync(
+            "running",
+            null,
+            null,
+            null,
+            It.IsAny<int>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EnsureRegularTaskProgressUpdate_AboveThreshold_ReportsCorrectDelta()
+    {
+        var progressMock = ProgressMock();
+        var facade = CreateFacade(progress: progressMock.Object);
+        var taskId = Guid.NewGuid();
+
+        // First update (under threshold — establishes 5 items in the dictionary)
+        await facade.EnsureRegularTaskProgressUpdate(taskId, new CrawlResponse { ProcessedItemCount = 5 });
+
+        // Simulate time passing, then update with 15 total items (delta = 15 - 0 = 15)
+        SimulateElapsedMinutes(facade, 6);
+        await facade.EnsureRegularTaskProgressUpdate(taskId, new CrawlResponse { ProcessedItemCount = 15 });
+
+        progressMock.Verify(p => p.UpdateExecutionAsync(
+            "running",
+            null,
+            null,
+            null,
+            15,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ── FinalizeScan ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FinalizeScan_CallsUpdateExecutionWithStatusCompleted()
+    {
+        var progressMock = ProgressMock();
+        var facade = CreateFacade(progress: progressMock.Object);
+
+        await facade.FinalizeScan();
+
+        progressMock.Verify(p => p.UpdateExecutionAsync(
+            "completed",
+            null,
+            null,
+            null,
+            It.IsAny<int>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task FinalizeScan_ReportsCorrectDelta_AfterPriorProgressUpdates()
+    {
+        var progressMock = ProgressMock();
+        var facade = CreateFacade(progress: progressMock.Object);
+        var taskId = Guid.NewGuid();
+
+        // Record some items first (below threshold so UpdateExecution not called yet)
+        await facade.EnsureRegularTaskProgressUpdate(taskId, new CrawlResponse { ProcessedItemCount = 20 });
+
+        await facade.FinalizeScan();
+
+        // delta = 20 - 0 (reportedItemsCount) = 20
+        progressMock.Verify(p => p.UpdateExecutionAsync(
+            "completed",
+            null,
+            null,
+            null,
+            20,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ── ICorePlatformFacade delegation ────────────────────────────────────────
+
+    [Fact]
+    public async Task DecryptData_DelegatesToCore()
+    {
+        var writerMock = WriterMock();
+        var core = CreateCore(writerMock.Object);
+        var facade = CreateFacade(core);
+
+        var payload = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(new { value = 42 });
+        var result = await facade.DecryptData<System.Text.Json.JsonElement>(Array.Empty<byte>(), payload);
+
+        Assert.Equal(42, result.GetProperty("value").GetInt32());
+    }
+
+    [Fact]
+    public async Task UploadActivityRecords_DelegatesToCore_DoesNotFlush()
+    {
+        var writerMock = WriterMock();
+        var core = CreateCore(writerMock.Object);
+        var facade = CreateFacade(core);
+
+        await facade.UploadActivityRecords(new List<ActivityRecord> { new() });
+
+        writerMock.Verify(w => w.SaveObject("activity_records", It.IsAny<ActivityRecord>(), true), Times.Once);
+        writerMock.Verify(w => w.FlushTablesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DecryptServiceBusMessage_DelegatesToCore_ThrowsNotSupported()
+    {
+        var facade = CreateFacade();
+
+        await Assert.ThrowsAsync<NotSupportedException>(() =>
+            facade.DecryptServiceBusMessage<object>("msg"));
+    }
+}

--- a/template/netwrix-csharp/ConnectorFramework.Tests/AACrawlTaskCorePlatformFacadeTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/AACrawlTaskCorePlatformFacadeTests.cs
@@ -87,7 +87,7 @@ public class AACrawlTaskCorePlatformFacadeTests
         await facade.EnsureRegularTaskProgressUpdate(Guid.NewGuid(), new CrawlResponse { ProcessedItemCount = 10 });
 
         progressMock.Verify(p => p.UpdateExecutionAsync(
-            "running",
+            ScanStatus.Running,
             null,
             null,
             null,
@@ -110,7 +110,7 @@ public class AACrawlTaskCorePlatformFacadeTests
         await facade.EnsureRegularTaskProgressUpdate(taskId, new CrawlResponse { ProcessedItemCount = 15 });
 
         progressMock.Verify(p => p.UpdateExecutionAsync(
-            "running",
+            ScanStatus.Running,
             null,
             null,
             null,
@@ -129,7 +129,7 @@ public class AACrawlTaskCorePlatformFacadeTests
         await facade.FinalizeScan();
 
         progressMock.Verify(p => p.UpdateExecutionAsync(
-            "completed",
+            ScanStatus.Completed,
             null,
             null,
             null,
@@ -151,7 +151,7 @@ public class AACrawlTaskCorePlatformFacadeTests
 
         // delta = 20 - 0 (reportedItemsCount) = 20
         progressMock.Verify(p => p.UpdateExecutionAsync(
-            "completed",
+            ScanStatus.Completed,
             null,
             null,
             null,

--- a/template/netwrix-csharp/ConnectorFramework.Tests/AACrawlTaskCorePlatformFacadeTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/AACrawlTaskCorePlatformFacadeTests.cs
@@ -175,7 +175,7 @@ public class AACrawlTaskCorePlatformFacadeTests
     }
 
     [Fact]
-    public async Task UploadActivityRecords_DelegatesToCore_DoesNotFlush()
+    public async Task UploadActivityRecords_IsNoOp_UntilTableExists()
     {
         var writerMock = WriterMock();
         var core = CreateCore(writerMock.Object);
@@ -183,8 +183,7 @@ public class AACrawlTaskCorePlatformFacadeTests
 
         await facade.UploadActivityRecords(new List<ActivityRecord> { new() });
 
-        writerMock.Verify(w => w.SaveObject("activity_records", It.IsAny<ActivityRecord>(), true), Times.Once);
-        writerMock.Verify(w => w.FlushTablesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        writerMock.Verify(w => w.SaveObject(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<bool>()), Times.Never);
     }
 
     [Fact]

--- a/template/netwrix-csharp/ConnectorFramework.Tests/BatchManagerTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/BatchManagerTests.cs
@@ -1,7 +1,7 @@
+using System.Net;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Moq.Protected;
-using System.Net;
 using Xunit;
 
 namespace Netwrix.ConnectorFramework.Tests;

--- a/template/netwrix-csharp/ConnectorFramework.Tests/BatchManagerTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/BatchManagerTests.cs
@@ -108,10 +108,9 @@ public class BatchManagerTests
 
         Assert.NotNull(capturedBody);
         var json = System.Text.Encoding.UTF8.GetString(capturedBody!);
-        Assert.Contains("scan_id", json);
-        Assert.Contains("scan_execution_id", json);
-        Assert.Contains("scanned_at", json);
+        Assert.Contains("sourceType", json);
         Assert.Contains("my_table", json);
+        Assert.Contains("key", json);
     }
 
     [Fact]

--- a/template/netwrix-csharp/ConnectorFramework.Tests/BatchManagerTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/BatchManagerTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Moq.Protected;
+using System.Net;
 using Xunit;
 
 namespace Netwrix.ConnectorFramework.Tests;
@@ -10,14 +11,33 @@ public class BatchManagerTests
     private static ConnectorRequestData MakeRequest(string? scanId = "scan-1", string? execId = "exec-1")
         => new("POST", "/connector/access_scan", new Dictionary<string, string>(), null, scanId, execId);
 
-    private static BatchManager CreateBatchManager(IHttpClientFactory? httpFactory = null)
+    private static BatchManager CreateBatchManager(
+        IHttpClientFactory? httpFactory = null,
+        Func<int, CancellationToken, Task>? onFlushed = null)
     {
         httpFactory ??= Mock.Of<IHttpClientFactory>();
         return new BatchManager(
             "test_table",
             httpFactory,
             MakeRequest(),
-            NullLogger<BatchManager>.Instance);
+            NullLogger<BatchManager>.Instance,
+            onFlushed);
+    }
+
+    private static (Mock<HttpMessageHandler> HandlerMock, IHttpClientFactory Factory) CreateSuccessFactory(
+        HttpStatusCode statusCode = HttpStatusCode.Accepted)
+    {
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(statusCode));
+
+        var httpClient = new HttpClient(handlerMock.Object);
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+        return (handlerMock, factoryMock.Object);
     }
 
     [Fact]
@@ -30,18 +50,8 @@ public class BatchManagerTests
     [Fact]
     public async Task AddObject_SingleItem_CanFlush()
     {
-        var handlerMock = new Mock<HttpMessageHandler>();
-        handlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage(System.Net.HttpStatusCode.Accepted));
-
-        var httpClient = new HttpClient(handlerMock.Object);
-        var httpFactoryMock = new Mock<IHttpClientFactory>();
-        httpFactoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
-
-        await using var bm = new BatchManager("test_table", httpFactoryMock.Object, MakeRequest(), NullLogger<BatchManager>.Instance);
+        var (_, factory) = CreateSuccessFactory();
+        await using var bm = new BatchManager("test_table", factory, MakeRequest(), NullLogger<BatchManager>.Instance);
         bm.AddObject(new { id = 1, name = "test" });
 
         await bm.FlushAsync(); // should not throw
@@ -84,7 +94,7 @@ public class BatchManagerTests
             {
                 capturedBody = await req.Content!.ReadAsByteArrayAsync();
             })
-            .ReturnsAsync(new HttpResponseMessage(System.Net.HttpStatusCode.Accepted));
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Accepted));
 
         var httpClient = new HttpClient(handlerMock.Object);
         var httpFactoryMock = new Mock<IHttpClientFactory>();
@@ -101,5 +111,114 @@ public class BatchManagerTests
         Assert.Contains("scan_execution_id", json);
         Assert.Contains("scanned_at", json);
         Assert.Contains("my_table", json);
+    }
+
+    [Fact]
+    public async Task OnFlushed_CalledWithCorrectCount_AfterSuccessfulFlush()
+    {
+        var (_, factory) = CreateSuccessFactory();
+        int? flushedCount = null;
+        Func<int, CancellationToken, Task> onFlushed = (count, _) =>
+        {
+            flushedCount = count;
+            return Task.CompletedTask;
+        };
+
+        await using var bm = new BatchManager("t", factory, MakeRequest(), NullLogger<BatchManager>.Instance, onFlushed);
+        bm.AddObject(new { x = 1 });
+        bm.AddObject(new { x = 2 });
+        bm.AddObject(new { x = 3 });
+
+        await bm.FlushAsync();
+
+        Assert.Equal(3, flushedCount);
+    }
+
+    [Fact]
+    public async Task OnFlushed_NotCalled_WhenNoObjects()
+    {
+        var (_, factory) = CreateSuccessFactory();
+        var called = false;
+        Func<int, CancellationToken, Task> onFlushed = (_, _) =>
+        {
+            called = true;
+            return Task.CompletedTask;
+        };
+
+        await using var bm = new BatchManager("t", factory, MakeRequest(), NullLogger<BatchManager>.Instance, onFlushed);
+        await bm.FlushAsync();
+
+        Assert.False(called);
+    }
+
+    [Fact]
+    public async Task AddObject_UpdateStatusFalse_DoesNotCountObject()
+    {
+        var (_, factory) = CreateSuccessFactory();
+        int? flushedCount = null;
+        Func<int, CancellationToken, Task> onFlushed = (count, _) =>
+        {
+            flushedCount = count;
+            return Task.CompletedTask;
+        };
+
+        await using var bm = new BatchManager("t", factory, MakeRequest(), NullLogger<BatchManager>.Instance, onFlushed);
+        bm.AddObject(new { x = 1 }, updateStatus: false);
+        bm.AddObject(new { x = 2 }, updateStatus: false);
+
+        await bm.FlushAsync();
+
+        // count was 0 so onFlushed should not be called
+        Assert.Null(flushedCount);
+    }
+
+    [Fact]
+    public async Task AddObject_MixedUpdateStatus_CountsOnlyStatusTrue()
+    {
+        var (_, factory) = CreateSuccessFactory();
+        int? flushedCount = null;
+        Func<int, CancellationToken, Task> onFlushed = (count, _) =>
+        {
+            flushedCount = count;
+            return Task.CompletedTask;
+        };
+
+        await using var bm = new BatchManager("t", factory, MakeRequest(), NullLogger<BatchManager>.Instance, onFlushed);
+        bm.AddObject(new { x = 1 }, updateStatus: true);
+        bm.AddObject(new { x = 2 }, updateStatus: false);
+        bm.AddObject(new { x = 3 }, updateStatus: true);
+
+        await bm.FlushAsync();
+
+        Assert.Equal(2, flushedCount);
+    }
+
+    [Fact]
+    public async Task OnFlushed_NotCalled_WhenFlushFails()
+    {
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+        var httpClient = new HttpClient(handlerMock.Object);
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        var called = false;
+        Func<int, CancellationToken, Task> onFlushed = (_, _) =>
+        {
+            called = true;
+            return Task.CompletedTask;
+        };
+
+        await using var bm = new BatchManager("t", factoryMock.Object, MakeRequest(), NullLogger<BatchManager>.Instance, onFlushed);
+        bm.AddObject(new { x = 1 });
+
+        await bm.FlushAsync();
+
+        Assert.False(called);
     }
 }

--- a/template/netwrix-csharp/ConnectorFramework.Tests/BatchManagerTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/BatchManagerTests.cs
@@ -9,7 +9,8 @@ namespace Netwrix.ConnectorFramework.Tests;
 public class BatchManagerTests
 {
     private static ConnectorRequestData MakeRequest(string? scanId = "scan-1", string? execId = "exec-1")
-        => new("POST", "/connector/access_scan", new Dictionary<string, string>(), null, scanId, execId);
+        => new("POST", "/connector/access_scan", new Dictionary<string, string>(), null,
+            new ExecutionContext(ScanId: scanId, ScanExecutionId: execId, SourceId: null, SourceType: null, SourceVersion: null, FunctionType: null));
 
     private static BatchManager CreateBatchManager(
         IHttpClientFactory? httpFactory = null,

--- a/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateStorageTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateStorageTests.cs
@@ -47,31 +47,6 @@ public class ConnectorStateStorageTests
         return (handlerMock, factoryMock.Object);
     }
 
-    /// <summary>Returns a factory that replies with sequentially different responses per call.</summary>
-    private static (Mock<HttpMessageHandler> Handler, IHttpClientFactory Factory) CreateSequentialFactory(
-        params (string Body, HttpStatusCode Code)[] responses)
-    {
-        var handlerMock = new Mock<HttpMessageHandler>();
-        var callIndex = 0;
-        handlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .Returns<HttpRequestMessage, CancellationToken>((_, _) =>
-            {
-                var (body, code) = responses[callIndex++];
-                return Task.FromResult(new HttpResponseMessage(code)
-                {
-                    Content = new StringContent(body, Encoding.UTF8, "application/json"),
-                });
-            });
-
-        var factoryMock = new Mock<IHttpClientFactory>();
-        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>()))
-            .Returns(() => new HttpClient(handlerMock.Object));
-        return (handlerMock, factoryMock.Object);
-    }
-
     private static string StateResponse(Dictionary<string, string> data)
         => JsonSerializer.Serialize(new { success = true, data });
 
@@ -95,12 +70,11 @@ public class ConnectorStateStorageTests
     }
 
     [Fact]
-    public async Task TryGetAsync_ReturnsValueAndEtag_WhenFound()
+    public async Task TryGetAsync_ReturnsValue_WhenFound()
     {
         var stateData = new Dictionary<string, string>
         {
             ["myKey"] = "\"hello\"",
-            ["__etag__:myKey"] = "etag-abc",
         };
         var (_, factory) = CreateFactory(StateResponse(stateData));
         var storage = CreateStorage(factory);
@@ -109,7 +83,7 @@ public class ConnectorStateStorageTests
 
         Assert.True(result.IsSuccess);
         Assert.Equal("hello", result.Value);
-        Assert.Equal("etag-abc", result.ETag);
+        Assert.Null(result.ETag);
     }
 
     [Fact]
@@ -136,7 +110,7 @@ public class ConnectorStateStorageTests
     // ── SetAsync ─────────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task SetAsync_PostsValueAndEtagCompanion()
+    public async Task SetAsync_PostsValue()
     {
         byte[]? capturedBody = null;
         var handlerMock = new Mock<HttpMessageHandler>();
@@ -161,7 +135,7 @@ public class ConnectorStateStorageTests
         var json = Encoding.UTF8.GetString(capturedBody!);
         Assert.Contains("\"cursor\"", json);
         Assert.Contains("page-5", json);
-        Assert.Contains("__etag__:cursor", json);
+        Assert.DoesNotContain("__etag__", json);
     }
 
     [Fact]
@@ -178,53 +152,32 @@ public class ConnectorStateStorageTests
     // ── SetIfMatchAsync ───────────────────────────────────────────────────────
 
     [Fact]
-    public async Task SetIfMatchAsync_Succeeds_AndReturnsNewEtag_WhenEtagMatches()
+    public async Task SetIfMatchAsync_WritesValueUnconditionally()
     {
-        var stateData = new Dictionary<string, string>
-        {
-            ["bookmark"] = "\"value-old\"",
-            ["__etag__:bookmark"] = "etag-1",
-        };
-        var (_, factory) = CreateSequentialFactory(
-            (StateResponse(stateData), HttpStatusCode.OK),  // GET
-            (OkResponse(), HttpStatusCode.OK));             // POST
+        byte[]? capturedBody = null;
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>(async (req, _) =>
+            {
+                capturedBody = await req.Content!.ReadAsByteArrayAsync();
+            })
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
 
-        var storage = CreateStorage(factory);
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(() => new HttpClient(handlerMock.Object));
+        var storage = CreateStorage(factoryMock.Object);
 
-        var newEtag = await storage.SetIfMatchAsync("bookmark", "value-new", "etag-1");
+        var result = await storage.SetIfMatchAsync("bookmark", "value-new", "any-etag");
 
-        Assert.NotNull(newEtag);
-        Assert.NotEqual("etag-1", newEtag);
-    }
-
-    [Fact]
-    public async Task SetIfMatchAsync_ThrowsStateChangedException_WhenEtagMismatch()
-    {
-        var stateData = new Dictionary<string, string>
-        {
-            ["bookmark"] = "\"value-old\"",
-            ["__etag__:bookmark"] = "etag-current",
-        };
-        var (_, factory) = CreateFactory(StateResponse(stateData));
-        var storage = CreateStorage(factory);
-
-        await Assert.ThrowsAsync<StateChangedException>(() =>
-            storage.SetIfMatchAsync("bookmark", "value-new", "etag-stale"));
-    }
-
-    [Fact]
-    public async Task SetIfMatchAsync_ThrowsStateChangedException_WhenKeyExistsButNullExpectedEtag()
-    {
-        var stateData = new Dictionary<string, string>
-        {
-            ["existing"] = "\"already-here\"",
-            ["__etag__:existing"] = "etag-xyz",
-        };
-        var (_, factory) = CreateFactory(StateResponse(stateData));
-        var storage = CreateStorage(factory);
-
-        await Assert.ThrowsAsync<StateChangedException>(() =>
-            storage.SetIfMatchAsync("existing", "new-value", expectedETag: null));
+        Assert.NotNull(capturedBody);
+        var json = Encoding.UTF8.GetString(capturedBody!);
+        Assert.Contains("\"bookmark\"", json);
+        Assert.Contains("value-new", json);
+        Assert.Equal(string.Empty, result);
     }
 
     // ── DeleteAsync ───────────────────────────────────────────────────────────
@@ -246,7 +199,6 @@ public class ConnectorStateStorageTests
         var stateData = new Dictionary<string, string>
         {
             ["target"] = "\"data\"",
-            ["__etag__:target"] = "etag-t",
         };
         HttpMethod? deleteMethod = null;
         string? deleteUrl = null;
@@ -291,9 +243,7 @@ public class ConnectorStateStorageTests
         var stateData = new Dictionary<string, string>
         {
             ["source/abc/bookmark"] = "\"v1\"",
-            ["__etag__:source/abc/bookmark"] = "e1",
             ["source/abc/cursor"] = "\"v2\"",
-            ["__etag__:source/abc/cursor"] = "e2",
             ["other/key"] = "\"v3\"",
         };
         string? deleteUrl = null;
@@ -333,14 +283,12 @@ public class ConnectorStateStorageTests
     // ── ListAllKeysAsync ──────────────────────────────────────────────────────
 
     [Fact]
-    public async Task ListAllKeysAsync_ReturnsKeys_ExcludingEtagCompanions()
+    public async Task ListAllKeysAsync_ReturnsKeys_MatchingPrefix()
     {
         var stateData = new Dictionary<string, string>
         {
             ["a/x"] = "\"1\"",
-            ["__etag__:a/x"] = "e1",
             ["a/y"] = "\"2\"",
-            ["__etag__:a/y"] = "e2",
             ["b/z"] = "\"3\"",
         };
         var (_, factory) = CreateFactory(StateResponse(stateData));

--- a/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateStorageTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateStorageTests.cs
@@ -183,40 +183,17 @@ public class ConnectorStateStorageTests
     // ── DeleteAsync ───────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task DeleteAsync_ReturnsFalse_WhenKeyAbsent()
+    public async Task DeleteAsync_ReturnsTrueAndIssuesDelete()
     {
-        var (_, factory) = CreateFactory(EmptyStateResponse());
-        var storage = CreateStorage(factory);
-
-        var deleted = await storage.DeleteAsync("ghost");
-
-        Assert.False(deleted);
-    }
-
-    [Fact]
-    public async Task DeleteAsync_ReturnsTrueAndIssuesDelete_WhenKeyPresent()
-    {
-        var stateData = new Dictionary<string, string>
-        {
-            ["target"] = "\"data\"",
-        };
         HttpMethod? deleteMethod = null;
         string? deleteUrl = null;
         var handlerMock = new Mock<HttpMessageHandler>();
-        var callIndex = 0;
         handlerMock.Protected()
             .Setup<Task<HttpResponseMessage>>("SendAsync",
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>())
             .Returns<HttpRequestMessage, CancellationToken>((req, _) =>
             {
-                if (callIndex++ == 0)
-                {
-                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                    {
-                        Content = new StringContent(StateResponse(stateData), Encoding.UTF8, "application/json"),
-                    });
-                }
                 deleteMethod = req.Method;
                 deleteUrl = req.RequestUri!.ToString();
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));

--- a/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateStorageTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateStorageTests.cs
@@ -248,7 +248,8 @@ public class ConnectorStateStorageTests
             ["target"] = "\"data\"",
             ["__etag__:target"] = "etag-t",
         };
-        HttpRequestMessage? deleteRequest = null;
+        HttpMethod? deleteMethod = null;
+        string? deleteUrl = null;
         var handlerMock = new Mock<HttpMessageHandler>();
         var callIndex = 0;
         handlerMock.Protected()
@@ -264,7 +265,8 @@ public class ConnectorStateStorageTests
                         Content = new StringContent(StateResponse(stateData), Encoding.UTF8, "application/json"),
                     });
                 }
-                deleteRequest = req;
+                deleteMethod = req.Method;
+                deleteUrl = req.RequestUri!.ToString();
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
             });
 
@@ -276,11 +278,9 @@ public class ConnectorStateStorageTests
         var deleted = await storage.DeleteAsync("target");
 
         Assert.True(deleted);
-        Assert.NotNull(deleteRequest);
-        Assert.Equal(HttpMethod.Delete, deleteRequest!.Method);
-        var url = deleteRequest.RequestUri!.ToString();
-        Assert.True(url.Contains("name%5B%5D=target") || url.Contains("name[]=target"),
-            $"Expected name[]=target in: {url}");
+        Assert.Equal(HttpMethod.Delete, deleteMethod);
+        Assert.NotNull(deleteUrl);
+        Assert.Contains("name=target", deleteUrl);
     }
 
     // ── DeleteAllAsync ────────────────────────────────────────────────────────
@@ -296,7 +296,7 @@ public class ConnectorStateStorageTests
             ["__etag__:source/abc/cursor"] = "e2",
             ["other/key"] = "\"v3\"",
         };
-        HttpRequestMessage? deleteRequest = null;
+        string? deleteUrl = null;
         var handlerMock = new Mock<HttpMessageHandler>();
         var callIndex = 0;
         handlerMock.Protected()
@@ -312,7 +312,7 @@ public class ConnectorStateStorageTests
                         Content = new StringContent(StateResponse(stateData), Encoding.UTF8, "application/json"),
                     });
                 }
-                deleteRequest = req;
+                deleteUrl = req.RequestUri!.ToString();
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
             });
 
@@ -323,12 +323,11 @@ public class ConnectorStateStorageTests
 
         await storage.DeleteAllAsync("source/abc");
 
-        Assert.NotNull(deleteRequest);
-        var url = deleteRequest!.RequestUri!.ToString();
-        Assert.True(url.Contains("bookmark") && url.Contains("cursor"),
-            $"Expected both bookmark and cursor in DELETE url: {url}");
-        Assert.DoesNotContain("other%2Fkey", url);
-        Assert.DoesNotContain("other/key", url);
+        Assert.NotNull(deleteUrl);
+        Assert.True(deleteUrl!.Contains("bookmark") && deleteUrl.Contains("cursor"),
+            $"Expected both bookmark and cursor in DELETE url: {deleteUrl}");
+        Assert.DoesNotContain("other%2Fkey", deleteUrl);
+        Assert.DoesNotContain("other/key", deleteUrl);
     }
 
     // ── ListAllKeysAsync ──────────────────────────────────────────────────────

--- a/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateStorageTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateStorageTests.cs
@@ -14,7 +14,8 @@ public class ConnectorStateStorageTests
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private static ConnectorRequestData MakeRequest(string? scanId = "scan-test")
-        => new("POST", "/", new Dictionary<string, string>(), null, scanId, null);
+        => new("POST", "/", new Dictionary<string, string>(), null,
+            new ExecutionContext(ScanId: scanId, ScanExecutionId: null, SourceId: null, SourceType: null, SourceVersion: null, FunctionType: null));
 
     private static ConnectorStateStorage CreateStorage(IHttpClientFactory factory, string? scanId = "scan-test")
         => new(MakeRequest(scanId), factory, NullLogger<ConnectorStateStorage>.Instance);

--- a/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateStorageTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateStorageTests.cs
@@ -1,0 +1,404 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Moq.Protected;
+using Netwrix.Overlord.Sdk.Core.Storage.Exceptions;
+using Xunit;
+
+namespace Netwrix.ConnectorFramework.Tests;
+
+public class ConnectorStateStorageTests
+{
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static ConnectorRequestData MakeRequest(string? scanId = "scan-test")
+        => new("POST", "/", new Dictionary<string, string>(), null, scanId, null);
+
+    private static ConnectorStateStorage CreateStorage(IHttpClientFactory factory, string? scanId = "scan-test")
+        => new(MakeRequest(scanId), factory, NullLogger<ConnectorStateStorage>.Instance);
+
+    /// <summary>Returns a factory that replies to every request with the same body/status.</summary>
+    private static (Mock<HttpMessageHandler> Handler, IHttpClientFactory Factory) CreateFactory(
+        string responseBody,
+        HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            // Return a fresh HttpResponseMessage each call: using var response in the SUT disposes
+            // the instance after reading, so reusing a pre-created response causes ObjectDisposedException.
+            .Returns<HttpRequestMessage, CancellationToken>((_, _) =>
+                Task.FromResult(new HttpResponseMessage(statusCode)
+                {
+                    Content = new StringContent(responseBody, Encoding.UTF8, "application/json"),
+                }));
+
+        // Return a fresh HttpClient on each call — the real IHttpClientFactory does the same,
+        // and it prevents ObjectDisposedException when a second call is made after the first
+        // disposes its client via 'using var'.
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(() => new HttpClient(handlerMock.Object));
+        return (handlerMock, factoryMock.Object);
+    }
+
+    /// <summary>Returns a factory that replies with sequentially different responses per call.</summary>
+    private static (Mock<HttpMessageHandler> Handler, IHttpClientFactory Factory) CreateSequentialFactory(
+        params (string Body, HttpStatusCode Code)[] responses)
+    {
+        var handlerMock = new Mock<HttpMessageHandler>();
+        var callIndex = 0;
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>((_, _) =>
+            {
+                var (body, code) = responses[callIndex++];
+                return Task.FromResult(new HttpResponseMessage(code)
+                {
+                    Content = new StringContent(body, Encoding.UTF8, "application/json"),
+                });
+            });
+
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(() => new HttpClient(handlerMock.Object));
+        return (handlerMock, factoryMock.Object);
+    }
+
+    private static string StateResponse(Dictionary<string, string> data)
+        => JsonSerializer.Serialize(new { success = true, data });
+
+    private static string EmptyStateResponse()
+        => JsonSerializer.Serialize(new { success = true, data = new Dictionary<string, string>() });
+
+    private static string OkResponse()
+        => JsonSerializer.Serialize(new { success = true });
+
+    // ── TryGetAsync ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task TryGetAsync_ReturnsNotFound_WhenKeyAbsent()
+    {
+        var (_, factory) = CreateFactory(EmptyStateResponse());
+        var storage = CreateStorage(factory);
+
+        var result = await storage.TryGetAsync<string>("missing");
+
+        Assert.False(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task TryGetAsync_ReturnsValueAndEtag_WhenFound()
+    {
+        var stateData = new Dictionary<string, string>
+        {
+            ["myKey"] = "\"hello\"",
+            ["__etag__:myKey"] = "etag-abc",
+        };
+        var (_, factory) = CreateFactory(StateResponse(stateData));
+        var storage = CreateStorage(factory);
+
+        var result = await storage.TryGetAsync<string>("myKey");
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("hello", result.Value);
+        Assert.Equal("etag-abc", result.ETag);
+    }
+
+    [Fact]
+    public async Task TryGetAsync_ReturnsNotFound_WhenScanIdIsNull()
+    {
+        var factoryMock = new Mock<IHttpClientFactory>();
+        var storage = CreateStorage(factoryMock.Object, scanId: null);
+
+        var result = await storage.TryGetAsync<string>("anyKey");
+
+        Assert.False(result.IsSuccess);
+        factoryMock.Verify(f => f.CreateClient(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TryGetAsync_ThrowsStorageException_OnHttpError()
+    {
+        var (_, factory) = CreateFactory("{}", HttpStatusCode.InternalServerError);
+        var storage = CreateStorage(factory);
+
+        await Assert.ThrowsAsync<StateStorageException>(() => storage.TryGetAsync<string>("myKey"));
+    }
+
+    // ── SetAsync ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SetAsync_PostsValueAndEtagCompanion()
+    {
+        byte[]? capturedBody = null;
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>(async (req, _) =>
+            {
+                capturedBody = await req.Content!.ReadAsByteArrayAsync();
+            })
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(() => new HttpClient(handlerMock.Object));
+        var storage = CreateStorage(factoryMock.Object);
+
+        await storage.SetAsync("cursor", "page-5");
+
+        Assert.NotNull(capturedBody);
+        var json = Encoding.UTF8.GetString(capturedBody!);
+        Assert.Contains("\"cursor\"", json);
+        Assert.Contains("page-5", json);
+        Assert.Contains("__etag__:cursor", json);
+    }
+
+    [Fact]
+    public async Task SetAsync_IsNoOp_WhenScanIdIsNull()
+    {
+        var factoryMock = new Mock<IHttpClientFactory>();
+        var storage = CreateStorage(factoryMock.Object, scanId: null);
+
+        await storage.SetAsync("key", "value");
+
+        factoryMock.Verify(f => f.CreateClient(It.IsAny<string>()), Times.Never);
+    }
+
+    // ── SetIfMatchAsync ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SetIfMatchAsync_Succeeds_AndReturnsNewEtag_WhenEtagMatches()
+    {
+        var stateData = new Dictionary<string, string>
+        {
+            ["bookmark"] = "\"value-old\"",
+            ["__etag__:bookmark"] = "etag-1",
+        };
+        var (_, factory) = CreateSequentialFactory(
+            (StateResponse(stateData), HttpStatusCode.OK),  // GET
+            (OkResponse(), HttpStatusCode.OK));             // POST
+
+        var storage = CreateStorage(factory);
+
+        var newEtag = await storage.SetIfMatchAsync("bookmark", "value-new", "etag-1");
+
+        Assert.NotNull(newEtag);
+        Assert.NotEqual("etag-1", newEtag);
+    }
+
+    [Fact]
+    public async Task SetIfMatchAsync_ThrowsStateChangedException_WhenEtagMismatch()
+    {
+        var stateData = new Dictionary<string, string>
+        {
+            ["bookmark"] = "\"value-old\"",
+            ["__etag__:bookmark"] = "etag-current",
+        };
+        var (_, factory) = CreateFactory(StateResponse(stateData));
+        var storage = CreateStorage(factory);
+
+        await Assert.ThrowsAsync<StateChangedException>(() =>
+            storage.SetIfMatchAsync("bookmark", "value-new", "etag-stale"));
+    }
+
+    [Fact]
+    public async Task SetIfMatchAsync_ThrowsStateChangedException_WhenKeyExistsButNullExpectedEtag()
+    {
+        var stateData = new Dictionary<string, string>
+        {
+            ["existing"] = "\"already-here\"",
+            ["__etag__:existing"] = "etag-xyz",
+        };
+        var (_, factory) = CreateFactory(StateResponse(stateData));
+        var storage = CreateStorage(factory);
+
+        await Assert.ThrowsAsync<StateChangedException>(() =>
+            storage.SetIfMatchAsync("existing", "new-value", expectedETag: null));
+    }
+
+    // ── DeleteAsync ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteAsync_ReturnsFalse_WhenKeyAbsent()
+    {
+        var (_, factory) = CreateFactory(EmptyStateResponse());
+        var storage = CreateStorage(factory);
+
+        var deleted = await storage.DeleteAsync("ghost");
+
+        Assert.False(deleted);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ReturnsTrueAndIssuesDelete_WhenKeyPresent()
+    {
+        var stateData = new Dictionary<string, string>
+        {
+            ["target"] = "\"data\"",
+            ["__etag__:target"] = "etag-t",
+        };
+        HttpRequestMessage? deleteRequest = null;
+        var handlerMock = new Mock<HttpMessageHandler>();
+        var callIndex = 0;
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>((req, _) =>
+            {
+                if (callIndex++ == 0)
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(StateResponse(stateData), Encoding.UTF8, "application/json"),
+                    });
+                }
+                deleteRequest = req;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            });
+
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(() => new HttpClient(handlerMock.Object));
+        var storage = CreateStorage(factoryMock.Object);
+
+        var deleted = await storage.DeleteAsync("target");
+
+        Assert.True(deleted);
+        Assert.NotNull(deleteRequest);
+        Assert.Equal(HttpMethod.Delete, deleteRequest!.Method);
+        var url = deleteRequest.RequestUri!.ToString();
+        Assert.True(url.Contains("name%5B%5D=target") || url.Contains("name[]=target"),
+            $"Expected name[]=target in: {url}");
+    }
+
+    // ── DeleteAllAsync ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteAllAsync_IssuesDeleteForPrefixMatchingKeys()
+    {
+        var stateData = new Dictionary<string, string>
+        {
+            ["source/abc/bookmark"] = "\"v1\"",
+            ["__etag__:source/abc/bookmark"] = "e1",
+            ["source/abc/cursor"] = "\"v2\"",
+            ["__etag__:source/abc/cursor"] = "e2",
+            ["other/key"] = "\"v3\"",
+        };
+        HttpRequestMessage? deleteRequest = null;
+        var handlerMock = new Mock<HttpMessageHandler>();
+        var callIndex = 0;
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>((req, _) =>
+            {
+                if (callIndex++ == 0)
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(StateResponse(stateData), Encoding.UTF8, "application/json"),
+                    });
+                }
+                deleteRequest = req;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            });
+
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(() => new HttpClient(handlerMock.Object));
+        var storage = CreateStorage(factoryMock.Object);
+
+        await storage.DeleteAllAsync("source/abc");
+
+        Assert.NotNull(deleteRequest);
+        var url = deleteRequest!.RequestUri!.ToString();
+        Assert.True(url.Contains("bookmark") && url.Contains("cursor"),
+            $"Expected both bookmark and cursor in DELETE url: {url}");
+        Assert.DoesNotContain("other%2Fkey", url);
+        Assert.DoesNotContain("other/key", url);
+    }
+
+    // ── ListAllKeysAsync ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListAllKeysAsync_ReturnsKeys_ExcludingEtagCompanions()
+    {
+        var stateData = new Dictionary<string, string>
+        {
+            ["a/x"] = "\"1\"",
+            ["__etag__:a/x"] = "e1",
+            ["a/y"] = "\"2\"",
+            ["__etag__:a/y"] = "e2",
+            ["b/z"] = "\"3\"",
+        };
+        var (_, factory) = CreateFactory(StateResponse(stateData));
+        var storage = CreateStorage(factory);
+
+        var keys = new List<string>();
+        await foreach (var k in storage.ListAllKeysAsync("a"))
+        {
+            keys.Add(k);
+        }
+
+        Assert.Equal(new[] { "a/x", "a/y" }, keys.ToArray());
+    }
+
+    [Fact]
+    public async Task ListAllKeysAsync_ReturnsEmpty_WhenScanIdIsNull()
+    {
+        var factoryMock = new Mock<IHttpClientFactory>();
+        var storage = CreateStorage(factoryMock.Object, scanId: null);
+
+        var keys = new List<string>();
+        await foreach (var k in storage.ListAllKeysAsync())
+        {
+            keys.Add(k);
+        }
+
+        Assert.Empty(keys);
+        factoryMock.Verify(f => f.CreateClient(It.IsAny<string>()), Times.Never);
+    }
+
+    // ── ListKeysAsync ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListKeysAsync_ReturnsKeysAtCorrectDepth()
+    {
+        var stateData = new Dictionary<string, string>
+        {
+            ["src/tenant/site/bookmark"] = "\"v\"",
+            ["src/tenant/site/cursor"] = "\"v\"",
+            ["src/tenant/other/bookmark"] = "\"v\"",
+            ["src/tenant/bookmark"] = "\"v\"", // depth=1 from src/tenant
+        };
+        var (_, factory) = CreateFactory(StateResponse(stateData));
+        var storage = CreateStorage(factory);
+
+        var depth1 = new List<string>();
+        await foreach (var k in storage.ListKeysAsync("src/tenant", depth: 1))
+        {
+            depth1.Add(k);
+        }
+
+        var depth2 = new List<string>();
+        await foreach (var k in storage.ListKeysAsync("src/tenant", depth: 2))
+        {
+            depth2.Add(k);
+        }
+
+        Assert.Equal(new[] { "src/tenant/bookmark" }, depth1.ToArray());
+        Assert.Equal(new[] { "src/tenant/other/bookmark", "src/tenant/site/bookmark", "src/tenant/site/cursor" }, depth2.ToArray());
+    }
+}

--- a/template/netwrix-csharp/ConnectorFramework.Tests/FunctionContextTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/FunctionContextTests.cs
@@ -1,11 +1,11 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Moq.Protected;
-using System.Net;
-using System.Text;
-using System.Text.Json;
 using Xunit;
 
 namespace Netwrix.ConnectorFramework.Tests;

--- a/template/netwrix-csharp/ConnectorFramework.Tests/FunctionContextTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/FunctionContextTests.cs
@@ -16,7 +16,8 @@ public class FunctionContextTests
     private static ConnectorRequestData MakeRequest(
         string? scanId = "scan-abc",
         string? execId = "exec-xyz")
-        => new("POST", "/connector/access_scan", new Dictionary<string, string>(), null, scanId, execId);
+        => new("POST", "/connector/access_scan", new Dictionary<string, string>(), null,
+            new ExecutionContext(ScanId: scanId, ScanExecutionId: execId, SourceId: null, SourceType: null, SourceVersion: null, FunctionType: null));
 
     private static FunctionContext CreateContext(
         IHttpClientFactory? factory = null,
@@ -37,7 +38,11 @@ public class FunctionContextTests
 
     private static async IAsyncEnumerable<string> ToAsyncKeys(params string[] keys)
     {
-        foreach (var k in keys) yield return k;
+        foreach (var k in keys)
+        {
+            yield return k;
+        }
+
         await Task.CompletedTask;
     }
 
@@ -218,6 +223,9 @@ public class FunctionContextTests
 
     // ── GetPriorExecutionAsync ───────────────────────────────────────────────
 
+    // scanExecutionId must be a valid GUID — the framework validates format before querying.
+    private const string PriorExecId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
     [Fact]
     public async Task GetPriorExecutionAsync_ReturnsExecution_WhenFound()
     {
@@ -226,17 +234,17 @@ public class FunctionContextTests
             success = true,
             data = new[]
             {
-                new { id = "exec-prior", status = "paused", completed_objects = 42 },
+                new { id = PriorExecId, status = "paused", completed_objects = 42 },
             },
         });
 
         var (_, factory) = CreateFactory(responseBody);
         await using var ctx = CreateContext(factory);
 
-        var result = await ctx.GetPriorExecutionAsync("exec-prior");
+        var result = await ctx.GetPriorExecutionAsync(PriorExecId);
 
         Assert.NotNull(result);
-        Assert.Equal("exec-prior", result!.Id);
+        Assert.Equal(PriorExecId, result!.Id);
         Assert.Equal("paused", result.Status);
         Assert.Equal(42, result.CompletedObjects);
     }
@@ -248,7 +256,7 @@ public class FunctionContextTests
         var (_, factory) = CreateFactory(responseBody);
         await using var ctx = CreateContext(factory);
 
-        var result = await ctx.GetPriorExecutionAsync("exec-prior");
+        var result = await ctx.GetPriorExecutionAsync(PriorExecId);
 
         Assert.Null(result);
     }
@@ -261,15 +269,24 @@ public class FunctionContextTests
             success = true,
             data = new[]
             {
-                new { id = "exec-prior", status = "paused", completed_objects = 0 },
+                new { id = PriorExecId, status = "paused", completed_objects = 0 },
             },
         });
 
         var (_, factory) = CreateFactory(responseBody);
         await using var ctx = CreateContext(factory);
 
-        var result = await ctx.GetPriorExecutionAsync("exec-prior");
+        var result = await ctx.GetPriorExecutionAsync(PriorExecId);
 
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetPriorExecutionAsync_ReturnsNull_WhenIdIsNotAGuid()
+    {
+        // Non-GUID IDs must be rejected before issuing any HTTP request.
+        await using var ctx = CreateContext();
+        var result = await ctx.GetPriorExecutionAsync("not-a-guid");
         Assert.Null(result);
     }
 
@@ -298,12 +315,12 @@ public class FunctionContextTests
         factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
 
         await using var ctx = CreateContext(factoryMock.Object);
-        await ctx.GetPriorExecutionAsync("exec-prior-123");
+        await ctx.GetPriorExecutionAsync(PriorExecId);
 
         Assert.NotNull(body);
         var json = Encoding.UTF8.GetString(body!);
         Assert.Contains("scan_executions", json);
-        Assert.Contains("exec-prior-123", json);
+        Assert.Contains(PriorExecId, json);
     }
 
     [Fact]

--- a/template/netwrix-csharp/ConnectorFramework.Tests/FunctionContextTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/FunctionContextTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Moq.Protected;
+using Netwrix.Overlord.Sdk.Core.Storage;
 using Xunit;
 
 namespace Netwrix.ConnectorFramework.Tests;
@@ -20,15 +21,24 @@ public class FunctionContextTests
     private static FunctionContext CreateContext(
         IHttpClientFactory? factory = null,
         string? scanId = "scan-abc",
-        string? execId = "exec-xyz")
+        string? execId = "exec-xyz",
+        IStateStorage? stateStorage = null)
     {
         factory ??= Mock.Of<IHttpClientFactory>();
+        stateStorage ??= Mock.Of<IStateStorage>();
         return new FunctionContext(
             MakeRequest(scanId, execId),
             new ConfigurationBuilder().Build(),
             factory,
             NullLogger<FunctionContext>.Instance,
-            NullLoggerFactory.Instance);
+            NullLoggerFactory.Instance,
+            stateStorage);
+    }
+
+    private static async IAsyncEnumerable<string> ToAsyncKeys(params string[] keys)
+    {
+        foreach (var k in keys) yield return k;
+        await Task.CompletedTask;
     }
 
     private static (Mock<HttpMessageHandler> HandlerMock, IHttpClientFactory Factory) CreateFactory(
@@ -123,31 +133,19 @@ public class FunctionContextTests
     // ── GetConnectorStateAsync ───────────────────────────────────────────────
 
     [Fact]
-    public async Task GetConnectorStateAsync_SendsGetWithScanId()
+    public async Task GetConnectorStateAsync_ReturnsDictionaryFromStorage()
     {
-        HttpRequestMessage? captured = null;
-        var handlerMock = new Mock<HttpMessageHandler>();
-        handlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .Callback<HttpRequestMessage, CancellationToken>((req, _) => { captured = req; })
-            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent(
-                    JsonSerializer.Serialize(new { success = true, data = new { key1 = "val1" } }),
-                    Encoding.UTF8, "application/json"),
-            });
+        var storageMock = new Mock<IStateStorage>();
+        storageMock
+            .Setup(s => s.ListAllKeysAsync("", It.IsAny<CancellationToken>()))
+            .Returns(ToAsyncKeys("key1"));
+        storageMock
+            .Setup(s => s.TryGetAsync<string>("key1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TryGetResult<string>("val1", null));
 
-        var client = new HttpClient(handlerMock.Object);
-        var factoryMock = new Mock<IHttpClientFactory>();
-        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
-
-        await using var ctx = CreateContext(factoryMock.Object, scanId: "scan-42");
+        await using var ctx = CreateContext(scanId: "scan-42", stateStorage: storageMock.Object);
         var result = await ctx.GetConnectorStateAsync();
 
-        Assert.Equal(HttpMethod.Get, captured!.Method);
-        Assert.Contains("scanId=scan-42", captured.RequestUri!.ToString());
         Assert.NotNull(result);
         Assert.Equal("val1", result!["key1"]);
     }
@@ -155,103 +153,67 @@ public class FunctionContextTests
     [Fact]
     public async Task GetConnectorStateAsync_ReturnsNull_WhenScanIdIsNull()
     {
-        await using var ctx = CreateContext(scanId: null);
+        var storageMock = new Mock<IStateStorage>();
+        await using var ctx = CreateContext(scanId: null, stateStorage: storageMock.Object);
         var result = await ctx.GetConnectorStateAsync();
         Assert.Null(result);
+        storageMock.Verify(s => s.ListAllKeysAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ── SetConnectorStateAsync ───────────────────────────────────────────────
 
     [Fact]
-    public async Task SetConnectorStateAsync_SendsPostWithScanIdAndData()
+    public async Task SetConnectorStateAsync_CallsSetAsyncForEachKey()
     {
-        byte[]? body = null;
-        HttpRequestMessage? captured = null;
-        var handlerMock = new Mock<HttpMessageHandler>();
-        handlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .Callback<HttpRequestMessage, CancellationToken>(async (req, _) =>
-            {
-                captured = req;
-                body = await req.Content!.ReadAsByteArrayAsync();
-            })
-            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+        var storageMock = new Mock<IStateStorage>();
+        storageMock
+            .Setup(s => s.SetAsync<object>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
 
-        var client = new HttpClient(handlerMock.Object);
-        var factoryMock = new Mock<IHttpClientFactory>();
-        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
-
-        await using var ctx = CreateContext(factoryMock.Object, scanId: "scan-42");
+        await using var ctx = CreateContext(scanId: "scan-42", stateStorage: storageMock.Object);
         await ctx.SetConnectorStateAsync(new Dictionary<string, object?> { ["cursor"] = "abc" });
 
-        Assert.Equal(HttpMethod.Post, captured!.Method);
-        Assert.NotNull(body);
-        var json = Encoding.UTF8.GetString(body!);
-        Assert.Contains("scan-42", json);
-        Assert.Contains("cursor", json);
-        Assert.Contains("abc", json);
+        storageMock.Verify(s => s.SetAsync<object>("cursor", "abc", It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task SetConnectorStateAsync_SkipsWhenScanIdIsNull()
     {
-        var factoryMock = new Mock<IHttpClientFactory>();
-        await using var ctx = CreateContext(factoryMock.Object, scanId: null);
+        var storageMock = new Mock<IStateStorage>();
+        await using var ctx = CreateContext(scanId: null, stateStorage: storageMock.Object);
         await ctx.SetConnectorStateAsync(new Dictionary<string, object?> { ["x"] = "y" });
-        factoryMock.Verify(f => f.CreateClient(It.IsAny<string>()), Times.Never);
+        storageMock.Verify(s => s.SetAsync<object>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ── DeleteConnectorStateAsync ────────────────────────────────────────────
 
     [Fact]
-    public async Task DeleteConnectorStateAsync_SendsDeleteWithScanId()
+    public async Task DeleteConnectorStateAsync_CallsDeleteAllAsync_WhenNamesIsNull()
     {
-        HttpRequestMessage? captured = null;
-        var handlerMock = new Mock<HttpMessageHandler>();
-        handlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .Callback<HttpRequestMessage, CancellationToken>((req, _) => { captured = req; })
-            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+        var storageMock = new Mock<IStateStorage>();
+        storageMock
+            .Setup(s => s.DeleteAllAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
 
-        var client = new HttpClient(handlerMock.Object);
-        var factoryMock = new Mock<IHttpClientFactory>();
-        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
-
-        await using var ctx = CreateContext(factoryMock.Object, scanId: "scan-42");
+        await using var ctx = CreateContext(scanId: "scan-42", stateStorage: storageMock.Object);
         await ctx.DeleteConnectorStateAsync();
 
-        Assert.Equal(HttpMethod.Delete, captured!.Method);
-        Assert.Contains("scanId=scan-42", captured.RequestUri!.ToString());
-        Assert.DoesNotContain("name", captured.RequestUri!.ToString());
+        storageMock.Verify(s => s.DeleteAllAsync("", It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task DeleteConnectorStateAsync_IncludesNamesInQueryString()
+    public async Task DeleteConnectorStateAsync_CallsDeleteAsyncForEachName()
     {
-        HttpRequestMessage? captured = null;
-        var handlerMock = new Mock<HttpMessageHandler>();
-        handlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .Callback<HttpRequestMessage, CancellationToken>((req, _) => { captured = req; })
-            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+        var storageMock = new Mock<IStateStorage>();
+        storageMock
+            .Setup(s => s.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
-        var client = new HttpClient(handlerMock.Object);
-        var factoryMock = new Mock<IHttpClientFactory>();
-        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
-
-        await using var ctx = CreateContext(factoryMock.Object, scanId: "scan-42");
+        await using var ctx = CreateContext(scanId: "scan-42", stateStorage: storageMock.Object);
         await ctx.DeleteConnectorStateAsync(new[] { "key1", "key2" });
 
-        var url = captured!.RequestUri!.ToString();
-        // .NET Uri may keep [] unencoded or percent-encode them — accept both forms
-        Assert.True(url.Contains("name%5B%5D=key1") || url.Contains("name[]=key1"), $"Expected name[]=key1 in: {url}");
-        Assert.True(url.Contains("name%5B%5D=key2") || url.Contains("name[]=key2"), $"Expected name[]=key2 in: {url}");
+        storageMock.Verify(s => s.DeleteAsync("key1", It.IsAny<CancellationToken>()), Times.Once);
+        storageMock.Verify(s => s.DeleteAsync("key2", It.IsAny<CancellationToken>()), Times.Once);
     }
 
     // ── GetPriorExecutionAsync ───────────────────────────────────────────────
@@ -409,7 +371,8 @@ public class FunctionContextTests
                 new ConfigurationBuilder().Build(),
                 Mock.Of<IHttpClientFactory>(),
                 loggerMock.Object,
-                NullLoggerFactory.Instance);
+                NullLoggerFactory.Instance,
+                Mock.Of<IStateStorage>());
 
             var secrets = ctx.Secrets;
 

--- a/template/netwrix-csharp/ConnectorFramework.Tests/FunctionContextTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/FunctionContextTests.cs
@@ -1,0 +1,434 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Moq.Protected;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace Netwrix.ConnectorFramework.Tests;
+
+public class FunctionContextTests
+{
+    private static ConnectorRequestData MakeRequest(
+        string? scanId = "scan-abc",
+        string? execId = "exec-xyz")
+        => new("POST", "/connector/access_scan", new Dictionary<string, string>(), null, scanId, execId);
+
+    private static FunctionContext CreateContext(
+        IHttpClientFactory? factory = null,
+        string? scanId = "scan-abc",
+        string? execId = "exec-xyz")
+    {
+        factory ??= Mock.Of<IHttpClientFactory>();
+        return new FunctionContext(
+            MakeRequest(scanId, execId),
+            new ConfigurationBuilder().Build(),
+            factory,
+            NullLogger<FunctionContext>.Instance,
+            NullLoggerFactory.Instance);
+    }
+
+    private static (Mock<HttpMessageHandler> HandlerMock, IHttpClientFactory Factory) CreateFactory(
+        string responseBody,
+        HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(responseBody, Encoding.UTF8, "application/json"),
+            });
+
+        var client = new HttpClient(handlerMock.Object);
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+        return (handlerMock, factoryMock.Object);
+    }
+
+    // ── UpdateExecutionAsync ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateExecutionAsync_SendsTotalObjectsAndCompletedObjects_WhenSet()
+    {
+        byte[]? body = null;
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>(async (req, _) =>
+            {
+                body = await req.Content!.ReadAsByteArrayAsync();
+            })
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+        var client = new HttpClient(handlerMock.Object);
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+
+        await using var ctx = CreateContext(factoryMock.Object, execId: "exec-1");
+        await ctx.UpdateExecutionAsync(totalObjects: 100, completedObjects: 50);
+
+        Assert.NotNull(body);
+        var json = Encoding.UTF8.GetString(body!);
+        Assert.Contains("\"totalObjects\"", json);
+        Assert.Contains("100", json);
+        Assert.Contains("\"completedObjects\"", json);
+        Assert.Contains("50", json);
+    }
+
+    [Fact]
+    public async Task UpdateExecutionAsync_DoesNotSendTotalObjects_WhenNull()
+    {
+        byte[]? body = null;
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>(async (req, _) =>
+            {
+                body = await req.Content!.ReadAsByteArrayAsync();
+            })
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+        var client = new HttpClient(handlerMock.Object);
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+
+        await using var ctx = CreateContext(factoryMock.Object, execId: "exec-1");
+        await ctx.UpdateExecutionAsync(status: "running");
+
+        Assert.NotNull(body);
+        var json = Encoding.UTF8.GetString(body!);
+        Assert.DoesNotContain("totalObjects", json);
+        Assert.DoesNotContain("completedObjects", json);
+    }
+
+    [Fact]
+    public async Task UpdateExecutionAsync_SkipsWhenScanExecutionIdIsNull()
+    {
+        var factoryMock = new Mock<IHttpClientFactory>();
+        await using var ctx = CreateContext(factoryMock.Object, execId: null);
+        await ctx.UpdateExecutionAsync(status: "running"); // should not throw or call HTTP
+        factoryMock.Verify(f => f.CreateClient(It.IsAny<string>()), Times.Never);
+    }
+
+    // ── GetConnectorStateAsync ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetConnectorStateAsync_SendsGetWithScanId()
+    {
+        HttpRequestMessage? captured = null;
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => { captured = req; })
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    JsonSerializer.Serialize(new { success = true, data = new { key1 = "val1" } }),
+                    Encoding.UTF8, "application/json"),
+            });
+
+        var client = new HttpClient(handlerMock.Object);
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+
+        await using var ctx = CreateContext(factoryMock.Object, scanId: "scan-42");
+        var result = await ctx.GetConnectorStateAsync();
+
+        Assert.Equal(HttpMethod.Get, captured!.Method);
+        Assert.Contains("scanId=scan-42", captured.RequestUri!.ToString());
+        Assert.NotNull(result);
+        Assert.Equal("val1", result!["key1"]);
+    }
+
+    [Fact]
+    public async Task GetConnectorStateAsync_ReturnsNull_WhenScanIdIsNull()
+    {
+        await using var ctx = CreateContext(scanId: null);
+        var result = await ctx.GetConnectorStateAsync();
+        Assert.Null(result);
+    }
+
+    // ── SetConnectorStateAsync ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task SetConnectorStateAsync_SendsPostWithScanIdAndData()
+    {
+        byte[]? body = null;
+        HttpRequestMessage? captured = null;
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>(async (req, _) =>
+            {
+                captured = req;
+                body = await req.Content!.ReadAsByteArrayAsync();
+            })
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+        var client = new HttpClient(handlerMock.Object);
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+
+        await using var ctx = CreateContext(factoryMock.Object, scanId: "scan-42");
+        await ctx.SetConnectorStateAsync(new Dictionary<string, object?> { ["cursor"] = "abc" });
+
+        Assert.Equal(HttpMethod.Post, captured!.Method);
+        Assert.NotNull(body);
+        var json = Encoding.UTF8.GetString(body!);
+        Assert.Contains("scan-42", json);
+        Assert.Contains("cursor", json);
+        Assert.Contains("abc", json);
+    }
+
+    [Fact]
+    public async Task SetConnectorStateAsync_SkipsWhenScanIdIsNull()
+    {
+        var factoryMock = new Mock<IHttpClientFactory>();
+        await using var ctx = CreateContext(factoryMock.Object, scanId: null);
+        await ctx.SetConnectorStateAsync(new Dictionary<string, object?> { ["x"] = "y" });
+        factoryMock.Verify(f => f.CreateClient(It.IsAny<string>()), Times.Never);
+    }
+
+    // ── DeleteConnectorStateAsync ────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteConnectorStateAsync_SendsDeleteWithScanId()
+    {
+        HttpRequestMessage? captured = null;
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => { captured = req; })
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+        var client = new HttpClient(handlerMock.Object);
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+
+        await using var ctx = CreateContext(factoryMock.Object, scanId: "scan-42");
+        await ctx.DeleteConnectorStateAsync();
+
+        Assert.Equal(HttpMethod.Delete, captured!.Method);
+        Assert.Contains("scanId=scan-42", captured.RequestUri!.ToString());
+        Assert.DoesNotContain("name", captured.RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task DeleteConnectorStateAsync_IncludesNamesInQueryString()
+    {
+        HttpRequestMessage? captured = null;
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => { captured = req; })
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+        var client = new HttpClient(handlerMock.Object);
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+
+        await using var ctx = CreateContext(factoryMock.Object, scanId: "scan-42");
+        await ctx.DeleteConnectorStateAsync(new[] { "key1", "key2" });
+
+        var url = captured!.RequestUri!.ToString();
+        // .NET Uri may keep [] unencoded or percent-encode them — accept both forms
+        Assert.True(url.Contains("name%5B%5D=key1") || url.Contains("name[]=key1"), $"Expected name[]=key1 in: {url}");
+        Assert.True(url.Contains("name%5B%5D=key2") || url.Contains("name[]=key2"), $"Expected name[]=key2 in: {url}");
+    }
+
+    // ── GetPriorExecutionAsync ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetPriorExecutionAsync_ReturnsExecution_WhenFound()
+    {
+        var responseBody = JsonSerializer.Serialize(new
+        {
+            success = true,
+            data = new[]
+            {
+                new { id = "exec-prior", status = "paused", completed_objects = 42 },
+            },
+        });
+
+        var (_, factory) = CreateFactory(responseBody);
+        await using var ctx = CreateContext(factory);
+
+        var result = await ctx.GetPriorExecutionAsync("exec-prior");
+
+        Assert.NotNull(result);
+        Assert.Equal("exec-prior", result!.Id);
+        Assert.Equal("paused", result.Status);
+        Assert.Equal(42, result.CompletedObjects);
+    }
+
+    [Fact]
+    public async Task GetPriorExecutionAsync_ReturnsNull_WhenNoDataFound()
+    {
+        var responseBody = JsonSerializer.Serialize(new { success = true, data = Array.Empty<object>() });
+        var (_, factory) = CreateFactory(responseBody);
+        await using var ctx = CreateContext(factory);
+
+        var result = await ctx.GetPriorExecutionAsync("exec-prior");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetPriorExecutionAsync_ReturnsNull_WhenCompletedObjectsIsZero()
+    {
+        var responseBody = JsonSerializer.Serialize(new
+        {
+            success = true,
+            data = new[]
+            {
+                new { id = "exec-prior", status = "paused", completed_objects = 0 },
+            },
+        });
+
+        var (_, factory) = CreateFactory(responseBody);
+        await using var ctx = CreateContext(factory);
+
+        var result = await ctx.GetPriorExecutionAsync("exec-prior");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetPriorExecutionAsync_SendsPostWithQuery()
+    {
+        byte[]? body = null;
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>(async (req, _) =>
+            {
+                body = await req.Content!.ReadAsByteArrayAsync();
+            })
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    JsonSerializer.Serialize(new { success = true, data = Array.Empty<object>() }),
+                    Encoding.UTF8, "application/json"),
+            });
+
+        var client = new HttpClient(handlerMock.Object);
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+
+        await using var ctx = CreateContext(factoryMock.Object);
+        await ctx.GetPriorExecutionAsync("exec-prior-123");
+
+        Assert.NotNull(body);
+        var json = Encoding.UTF8.GetString(body!);
+        Assert.Contains("scan_executions", json);
+        Assert.Contains("exec-prior-123", json);
+    }
+
+    [Fact]
+    public async Task GetPriorExecutionAsync_ReturnsNull_ForEmptyId()
+    {
+        await using var ctx = CreateContext();
+        var result = await ctx.GetPriorExecutionAsync("");
+        Assert.Null(result);
+    }
+
+    // ── GetObjectSuccessResponse ─────────────────────────────────────────────
+
+    [Fact]
+    public void GetObjectSuccessResponse_ReturnsBase64EncodedData()
+    {
+        var data = new byte[] { 1, 2, 3, 4, 5 };
+        var expected = Convert.ToBase64String(data);
+
+        var response = FunctionContext.GetObjectSuccessResponse(data);
+        var json = JsonSerializer.Serialize(response);
+
+        Assert.Contains("200", json);
+        Assert.Contains(expected, json);
+    }
+
+    [Fact]
+    public void GetObjectSuccessResponse_EmptyArray_ReturnsEmptyBase64()
+    {
+        var response = FunctionContext.GetObjectSuccessResponse(Array.Empty<byte>());
+        var json = JsonSerializer.Serialize(response);
+        Assert.Contains("200", json);
+        Assert.Contains(Convert.ToBase64String(Array.Empty<byte>()), json);
+    }
+
+    // ── SaveObject ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SaveObject_DelegatesToGetTable()
+    {
+        var (_, factory) = CreateFactory("{}", HttpStatusCode.Accepted);
+        await using var ctx = CreateContext(factory);
+
+        ctx.SaveObject("my_table", new { x = 1 });
+
+        // GetTable should have created a BatchManager for "my_table"
+        var bm = ctx.GetTable("my_table");
+        Assert.NotNull(bm);
+    }
+
+    // ── SECRET_MAPPINGS ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void Secrets_SecretMappings_LogsWarning_WhenSecretNotFound()
+    {
+        // On test machines /var/secrets doesn't exist, so dict is empty.
+        // SECRET_MAPPINGS references a non-existent secret → warning should be logged.
+        var loggerMock = new Mock<ILogger<FunctionContext>>();
+        loggerMock.Setup(x => x.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+
+        Environment.SetEnvironmentVariable("SECRET_MAPPINGS", "myKey:nonExistentSecret");
+        try
+        {
+            var ctx = new FunctionContext(
+                MakeRequest(),
+                new ConfigurationBuilder().Build(),
+                Mock.Of<IHttpClientFactory>(),
+                loggerMock.Object,
+                NullLoggerFactory.Instance);
+
+            var secrets = ctx.Secrets;
+
+            // The aliased key should not be in the dict since the secret file doesn't exist
+            Assert.False(secrets.ContainsKey("myKey"));
+
+            // A warning should have been logged
+            loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("nonExistentSecret")),
+                    It.IsAny<Exception?>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SECRET_MAPPINGS", null);
+        }
+    }
+}

--- a/template/netwrix-csharp/ConnectorFramework.Tests/ProgramTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/ProgramTests.cs
@@ -1,0 +1,135 @@
+using Xunit;
+
+namespace Netwrix.ConnectorFramework.Tests;
+
+// Process-level env vars mutated in these tests are not thread-safe across parallel runs.
+// Run this collection sequentially to avoid flaky interference with other test classes.
+[Collection("Sequential")]
+public class ProgramTests
+{
+    // ── IsJobMode ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsJobMode_ReturnsTrue_WhenExecutionModeIsJob()
+    {
+        Environment.SetEnvironmentVariable("EXECUTION_MODE", "job");
+        Environment.SetEnvironmentVariable("REQUEST_DATA", null);
+        try
+        {
+            Assert.True(Program.IsJobMode());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("EXECUTION_MODE", null);
+        }
+    }
+
+    [Fact]
+    public void IsJobMode_ReturnsTrue_WhenRequestDataIsSet_AndExecutionModeIsAbsent()
+    {
+        Environment.SetEnvironmentVariable("EXECUTION_MODE", null);
+        Environment.SetEnvironmentVariable("REQUEST_DATA", "{\"scanExecutionId\":\"abc\"}");
+        try
+        {
+            Assert.True(Program.IsJobMode());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("REQUEST_DATA", null);
+        }
+    }
+
+    [Fact]
+    public void IsJobMode_ReturnsFalse_WhenNeitherIsSet()
+    {
+        Environment.SetEnvironmentVariable("EXECUTION_MODE", null);
+        Environment.SetEnvironmentVariable("REQUEST_DATA", null);
+        Assert.False(Program.IsJobMode());
+    }
+
+    [Fact]
+    public void IsJobMode_ReturnsFalse_WhenExecutionModeIsNotJob()
+    {
+        Environment.SetEnvironmentVariable("EXECUTION_MODE", "http");
+        Environment.SetEnvironmentVariable("REQUEST_DATA", null);
+        try
+        {
+            Assert.False(Program.IsJobMode());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("EXECUTION_MODE", null);
+        }
+    }
+
+    // ── BuildRequestPath ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildRequestPath_UsesRequestPath_WhenExplicitlySet()
+    {
+        Environment.SetEnvironmentVariable("REQUEST_PATH", "/connector/access_scan");
+        Environment.SetEnvironmentVariable("FUNCTION_TYPE", null);
+        try
+        {
+            Assert.Equal("/connector/access_scan", Program.BuildRequestPath());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("REQUEST_PATH", null);
+        }
+    }
+
+    [Fact]
+    public void BuildRequestPath_DerivesPathFromFunctionType_WhenRequestPathIsAbsent()
+    {
+        Environment.SetEnvironmentVariable("REQUEST_PATH", null);
+        Environment.SetEnvironmentVariable("FUNCTION_TYPE", "access-scan");
+        try
+        {
+            Assert.Equal("/connector/access_scan", Program.BuildRequestPath());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("FUNCTION_TYPE", null);
+        }
+    }
+
+    [Fact]
+    public void BuildRequestPath_DerivesPathFromFunctionType_ReplacingHyphensWithUnderscores()
+    {
+        Environment.SetEnvironmentVariable("REQUEST_PATH", null);
+        Environment.SetEnvironmentVariable("FUNCTION_TYPE", "sensitive-data-scan");
+        try
+        {
+            Assert.Equal("/connector/sensitive_data_scan", Program.BuildRequestPath());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("FUNCTION_TYPE", null);
+        }
+    }
+
+    [Fact]
+    public void BuildRequestPath_DefaultsToTestConnection_WhenBothAreAbsent()
+    {
+        Environment.SetEnvironmentVariable("REQUEST_PATH", null);
+        Environment.SetEnvironmentVariable("FUNCTION_TYPE", null);
+        Assert.Equal("/connector/test_connection", Program.BuildRequestPath());
+    }
+
+    [Fact]
+    public void BuildRequestPath_PrefersRequestPath_OverFunctionType()
+    {
+        Environment.SetEnvironmentVariable("REQUEST_PATH", "/connector/access_scan");
+        Environment.SetEnvironmentVariable("FUNCTION_TYPE", "sensitive-data-scan");
+        try
+        {
+            Assert.Equal("/connector/access_scan", Program.BuildRequestPath());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("REQUEST_PATH", null);
+            Environment.SetEnvironmentVariable("FUNCTION_TYPE", null);
+        }
+    }
+}

--- a/template/netwrix-csharp/ConnectorFramework.Tests/ServiceUrlHelperTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/ServiceUrlHelperTests.cs
@@ -1,0 +1,119 @@
+using Xunit;
+
+namespace Netwrix.ConnectorFramework.Tests;
+
+public class ServiceUrlHelperTests : IDisposable
+{
+    private readonly List<string> _envVarsToClean = new();
+
+    private void SetEnv(string name, string? value)
+    {
+        _envVarsToClean.Add(name);
+        Environment.SetEnvironmentVariable(name, value);
+    }
+
+    public void Dispose()
+    {
+        foreach (var name in _envVarsToClean)
+        {
+            Environment.SetEnvironmentVariable(name, null);
+        }
+    }
+
+    // ── Env var override ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Resolve_ReturnsOverrideUrl_WhenAbsoluteUri()
+    {
+        SetEnv("APP_TEST", "http://my-service:9090");
+        var result = ServiceUrlHelper.Resolve("APP_TEST", "my-service");
+        Assert.Equal("http://my-service:9090", result);
+    }
+
+    [Fact]
+    public void Resolve_IgnoresOverride_WhenBareServiceName()
+    {
+        SetEnv("APP_TEST", "my-service");
+        SetEnv("RUN_LOCAL", null);
+        SetEnv("USE_OPENFAAS_GATEWAY", null);
+        SetEnv("COMMON_FUNCTIONS_NAMESPACE", null);
+        var result = ServiceUrlHelper.Resolve("APP_TEST", "my-service");
+        Assert.Equal("http://my-service.access-analyzer.svc.cluster.local:80", result);
+    }
+
+    [Fact]
+    public void Resolve_IgnoresOverride_WhenEmptyEnvVar()
+    {
+        SetEnv("APP_TEST", "");
+        SetEnv("RUN_LOCAL", null);
+        SetEnv("USE_OPENFAAS_GATEWAY", null);
+        SetEnv("COMMON_FUNCTIONS_NAMESPACE", null);
+        var result = ServiceUrlHelper.Resolve("APP_TEST", "my-service");
+        Assert.Equal("http://my-service.access-analyzer.svc.cluster.local:80", result);
+    }
+
+    [Fact]
+    public void Resolve_IgnoresOverride_WhenEnvVarNotSet()
+    {
+        SetEnv("RUN_LOCAL", null);
+        SetEnv("USE_OPENFAAS_GATEWAY", null);
+        SetEnv("COMMON_FUNCTIONS_NAMESPACE", null);
+        var result = ServiceUrlHelper.Resolve("APP_TEST_UNSET_XYZ", "my-service");
+        Assert.Equal("http://my-service.access-analyzer.svc.cluster.local:80", result);
+    }
+
+    // ── RUN_LOCAL ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Resolve_ReturnsLocalUrl_WhenRunLocalTrue()
+    {
+        SetEnv("RUN_LOCAL", "true");
+        SetEnv("USE_OPENFAAS_GATEWAY", null);
+        var result = ServiceUrlHelper.Resolve("APP_TEST_UNSET_XYZ", "my-service");
+        Assert.Equal("http://my-service:8080", result);
+    }
+
+    // ── OpenFaaS ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Resolve_ReturnsOpenfaasUrl_WhenUseOpenfaasGatewayTrue()
+    {
+        SetEnv("RUN_LOCAL", null);
+        SetEnv("USE_OPENFAAS_GATEWAY", "true");
+        SetEnv("OPENFAAS_GATEWAY", null);
+        var result = ServiceUrlHelper.Resolve("APP_TEST_UNSET_XYZ", "my-service");
+        Assert.Equal("http://gateway.openfaas:8080/function/my-service", result);
+    }
+
+    [Fact]
+    public void Resolve_ReturnsAsyncOpenfaasUrl_WhenUseAsyncTrue()
+    {
+        SetEnv("RUN_LOCAL", null);
+        SetEnv("USE_OPENFAAS_GATEWAY", "true");
+        SetEnv("OPENFAAS_GATEWAY", null);
+        var result = ServiceUrlHelper.Resolve("APP_TEST_UNSET_XYZ", "my-service", useAsync: true);
+        Assert.Equal("http://gateway.openfaas:8080/async-function/my-service", result);
+    }
+
+    // ── Kubernetes ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Resolve_ReturnsKubernetesFqdn_WhenNoFlagsSet()
+    {
+        SetEnv("RUN_LOCAL", null);
+        SetEnv("USE_OPENFAAS_GATEWAY", null);
+        SetEnv("COMMON_FUNCTIONS_NAMESPACE", null);
+        var result = ServiceUrlHelper.Resolve("APP_TEST_UNSET_XYZ", "my-service");
+        Assert.Equal("http://my-service.access-analyzer.svc.cluster.local:80", result);
+    }
+
+    [Fact]
+    public void Resolve_UsesCustomNamespace_WhenCommonFunctionsNamespaceSet()
+    {
+        SetEnv("RUN_LOCAL", null);
+        SetEnv("USE_OPENFAAS_GATEWAY", null);
+        SetEnv("COMMON_FUNCTIONS_NAMESPACE", "my-ns");
+        var result = ServiceUrlHelper.Resolve("APP_TEST_UNSET_XYZ", "my-service");
+        Assert.Equal("http://my-service.my-ns.svc.cluster.local:80", result);
+    }
+}

--- a/template/netwrix-csharp/ConnectorFramework.Tests/StateManagerTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/StateManagerTests.cs
@@ -8,13 +8,15 @@ public class StateManagerTests
 {
     private static StateManager CreateManager(
         Mock<RedisSignalHandler>? redisMock = null,
-        SupportedStates? states = null)
+        SupportedStates? states = null,
+        Mock<IScanProgress>? progressMock = null)
     {
         var redis = redisMock?.Object
             ?? new RedisSignalHandler(
                 Mock.Of<StackExchange.Redis.IConnectionMultiplexer>(),
                 NullLogger<RedisSignalHandler>.Instance);
-        return new StateManager(redis, new ScanShutdownService(), NullLogger<StateManager>.Instance, states);
+        var progress = progressMock?.Object ?? Mock.Of<IScanProgress>();
+        return new StateManager(redis, new ScanShutdownService(), progress, NullLogger<StateManager>.Instance, states);
     }
 
     // ── Initialization ─────────────────────────────────────────────────────
@@ -23,7 +25,7 @@ public class StateManagerTests
     public void NewManager_StartsInRunningState()
     {
         var mgr = CreateManager();
-        Assert.Equal("running", mgr.CurrentState);
+        Assert.Equal(ScanStatus.Running, mgr.CurrentState);
     }
 
     [Fact]
@@ -48,38 +50,38 @@ public class StateManagerTests
     public async Task SetState_ValidTransition_Running_To_Stopping_Succeeds()
     {
         var mgr = CreateManager();
-        var result = await mgr.SetStateAsync("stopping");
+        var result = await mgr.SetStateAsync(ScanStatus.Stopping);
         Assert.True(result);
-        Assert.Equal("stopping", mgr.CurrentState);
+        Assert.Equal(ScanStatus.Stopping, mgr.CurrentState);
     }
 
     [Fact]
     public async Task SetState_ValidTransition_Stopping_To_Stopped_Succeeds()
     {
         var mgr = CreateManager();
-        await mgr.SetStateAsync("stopping");
-        var result = await mgr.SetStateAsync("stopped");
+        await mgr.SetStateAsync(ScanStatus.Stopping);
+        var result = await mgr.SetStateAsync(ScanStatus.Stopped);
         Assert.True(result);
-        Assert.Equal("stopped", mgr.CurrentState);
+        Assert.Equal(ScanStatus.Stopped, mgr.CurrentState);
     }
 
     [Fact]
     public async Task SetState_InvalidTransition_Returns_False_And_StateUnchanged()
     {
         var mgr = CreateManager();
-        await mgr.SetStateAsync("stopping");
-        await mgr.SetStateAsync("stopped");
+        await mgr.SetStateAsync(ScanStatus.Stopping);
+        await mgr.SetStateAsync(ScanStatus.Stopped);
 
-        var result = await mgr.SetStateAsync("running"); // invalid from stopped
+        var result = await mgr.SetStateAsync(ScanStatus.Running); // invalid from stopped
         Assert.False(result);
-        Assert.Equal("stopped", mgr.CurrentState);
+        Assert.Equal(ScanStatus.Stopped, mgr.CurrentState);
     }
 
     [Fact]
     public async Task SetState_SameState_Returns_True()
     {
         var mgr = CreateManager();
-        var result = await mgr.SetStateAsync("running");
+        var result = await mgr.SetStateAsync(ScanStatus.Running);
         Assert.True(result);
     }
 
@@ -87,18 +89,18 @@ public class StateManagerTests
     public async Task SetState_ValidTransition_Running_To_Completed()
     {
         var mgr = CreateManager();
-        var result = await mgr.SetStateAsync("completed");
+        var result = await mgr.SetStateAsync(ScanStatus.Completed);
         Assert.True(result);
-        Assert.Equal("completed", mgr.CurrentState);
+        Assert.Equal(ScanStatus.Completed, mgr.CurrentState);
     }
 
     [Fact]
     public async Task SetState_ValidTransition_Running_To_Failed()
     {
         var mgr = CreateManager();
-        var result = await mgr.SetStateAsync("failed");
+        var result = await mgr.SetStateAsync(ScanStatus.Failed);
         Assert.True(result);
-        Assert.Equal("failed", mgr.CurrentState);
+        Assert.Equal(ScanStatus.Failed, mgr.CurrentState);
     }
 
     // ── Pause / Resume transitions ─────────────────────────────────────────
@@ -108,61 +110,61 @@ public class StateManagerTests
     {
         var mgr = CreateManager(states: new SupportedStates(Stop: true, Pause: true, Resume: true));
 
-        Assert.True(await mgr.SetStateAsync("pausing"));
-        Assert.Equal("pausing", mgr.CurrentState);
+        Assert.True(await mgr.SetStateAsync(ScanStatus.Pausing));
+        Assert.Equal(ScanStatus.Pausing, mgr.CurrentState);
 
-        Assert.True(await mgr.SetStateAsync("paused"));
-        Assert.Equal("paused", mgr.CurrentState);
+        Assert.True(await mgr.SetStateAsync(ScanStatus.Paused));
+        Assert.Equal(ScanStatus.Paused, mgr.CurrentState);
 
-        Assert.True(await mgr.SetStateAsync("resuming"));
-        Assert.Equal("resuming", mgr.CurrentState);
+        Assert.True(await mgr.SetStateAsync(ScanStatus.Resuming));
+        Assert.Equal(ScanStatus.Resuming, mgr.CurrentState);
 
-        Assert.True(await mgr.SetStateAsync("running"));
-        Assert.Equal("running", mgr.CurrentState);
+        Assert.True(await mgr.SetStateAsync(ScanStatus.Running));
+        Assert.Equal(ScanStatus.Running, mgr.CurrentState);
     }
 
     [Fact]
     public async Task PausedToStopped_IsValid()
     {
         var mgr = CreateManager();
-        await mgr.SetStateAsync("pausing");
-        await mgr.SetStateAsync("paused");
-        var result = await mgr.SetStateAsync("stopped");
+        await mgr.SetStateAsync(ScanStatus.Pausing);
+        await mgr.SetStateAsync(ScanStatus.Paused);
+        var result = await mgr.SetStateAsync(ScanStatus.Stopped);
         Assert.True(result);
-        Assert.Equal("stopped", mgr.CurrentState);
+        Assert.Equal(ScanStatus.Stopped, mgr.CurrentState);
     }
 
     [Fact]
     public async Task PausedToRunning_IsInvalid()
     {
         var mgr = CreateManager();
-        await mgr.SetStateAsync("pausing");
-        await mgr.SetStateAsync("paused");
-        var result = await mgr.SetStateAsync("running"); // must go through resuming
+        await mgr.SetStateAsync(ScanStatus.Pausing);
+        await mgr.SetStateAsync(ScanStatus.Paused);
+        var result = await mgr.SetStateAsync(ScanStatus.Running); // must go through resuming
         Assert.False(result);
-        Assert.Equal("paused", mgr.CurrentState);
+        Assert.Equal(ScanStatus.Paused, mgr.CurrentState);
     }
 
     [Fact]
     public async Task PausingToStopped_IsInvalid()
     {
         var mgr = CreateManager();
-        await mgr.SetStateAsync("pausing");
-        var result = await mgr.SetStateAsync("stopped");
+        await mgr.SetStateAsync(ScanStatus.Pausing);
+        var result = await mgr.SetStateAsync(ScanStatus.Stopped);
         Assert.False(result);
-        Assert.Equal("pausing", mgr.CurrentState);
+        Assert.Equal(ScanStatus.Pausing, mgr.CurrentState);
     }
 
     [Fact]
     public async Task ResumingToPaused_IsInvalid()
     {
         var mgr = CreateManager();
-        await mgr.SetStateAsync("pausing");
-        await mgr.SetStateAsync("paused");
-        await mgr.SetStateAsync("resuming");
-        var result = await mgr.SetStateAsync("paused");
+        await mgr.SetStateAsync(ScanStatus.Pausing);
+        await mgr.SetStateAsync(ScanStatus.Paused);
+        await mgr.SetStateAsync(ScanStatus.Resuming);
+        var result = await mgr.SetStateAsync(ScanStatus.Paused);
         Assert.False(result);
-        Assert.Equal("resuming", mgr.CurrentState);
+        Assert.Equal(ScanStatus.Resuming, mgr.CurrentState);
     }
 
     // ── Callbacks ──────────────────────────────────────────────────────────
@@ -181,10 +183,10 @@ public class StateManagerTests
             return Task.CompletedTask;
         });
 
-        await mgr.SetStateAsync("stopping");
+        await mgr.SetStateAsync(ScanStatus.Stopping);
 
-        Assert.Equal("running", capturedOld);
-        Assert.Equal("stopping", capturedNew);
+        Assert.Equal(ScanStatus.Running, capturedOld);
+        Assert.Equal(ScanStatus.Stopping, capturedNew);
     }
 
     [Fact]
@@ -196,7 +198,7 @@ public class StateManagerTests
         mgr.OnStateChange((_, _) => { invocations++; return Task.CompletedTask; });
         mgr.OnStateChange((_, _) => { invocations++; return Task.CompletedTask; });
 
-        await mgr.SetStateAsync("stopping");
+        await mgr.SetStateAsync(ScanStatus.Stopping);
 
         Assert.Equal(2, invocations);
     }
@@ -210,7 +212,7 @@ public class StateManagerTests
         mgr.OnStateChange((_, _) => throw new Exception("callback error"));
         mgr.OnStateChange((_, _) => { secondInvoked = true; return Task.CompletedTask; });
 
-        await mgr.SetStateAsync("stopping"); // should not throw
+        await mgr.SetStateAsync(ScanStatus.Stopping); // should not throw
 
         Assert.True(secondInvoked);
     }
@@ -227,11 +229,11 @@ public class StateManagerTests
             return Task.CompletedTask;
         });
 
-        await mgr.SetStateAsync("stopping");
-        await mgr.SetStateAsync("stopped");
+        await mgr.SetStateAsync(ScanStatus.Stopping);
+        await mgr.SetStateAsync(ScanStatus.Stopped);
 
-        Assert.Equal(("running", "stopping"), transitions[0]);
-        Assert.Equal(("stopping", "stopped"), transitions[1]);
+        Assert.Equal((ScanStatus.Running, ScanStatus.Stopping), transitions[0]);
+        Assert.Equal((ScanStatus.Stopping, ScanStatus.Stopped), transitions[1]);
     }
 
     // ── Shutdown ──────────────────────────────────────────────────────────
@@ -248,11 +250,11 @@ public class StateManagerTests
         redisMock.Setup(r => r.CleanupStreamsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        var mgr = new StateManager(redisMock.Object, new ScanShutdownService(), NullLogger<StateManager>.Instance);
-        var result = await mgr.ShutdownAsync("exec-123", "completed");
+        var mgr = new StateManager(redisMock.Object, new ScanShutdownService(), Mock.Of<IScanProgress>(), NullLogger<StateManager>.Instance);
+        var result = await mgr.ShutdownAsync("exec-123", ScanStatus.Completed);
 
         Assert.True(result);
-        Assert.Equal("completed", mgr.CurrentState);
+        Assert.Equal(ScanStatus.Completed, mgr.CurrentState);
         Assert.True(mgr.IsShutdown);
     }
 
@@ -263,12 +265,12 @@ public class StateManagerTests
             Mock.Of<StackExchange.Redis.IConnectionMultiplexer>(),
             NullLogger<RedisSignalHandler>.Instance);
 
-        var mgr = new StateManager(redisMock.Object, new ScanShutdownService(), NullLogger<StateManager>.Instance);
-        await mgr.SetStateAsync("stopping");
-        await mgr.SetStateAsync("stopped");
+        var mgr = new StateManager(redisMock.Object, new ScanShutdownService(), Mock.Of<IScanProgress>(), NullLogger<StateManager>.Instance);
+        await mgr.SetStateAsync(ScanStatus.Stopping);
+        await mgr.SetStateAsync(ScanStatus.Stopped);
 
         // stopped -> completed is invalid
-        var result = await mgr.ShutdownAsync("exec-123", "completed");
+        var result = await mgr.ShutdownAsync("exec-123", ScanStatus.Completed);
 
         Assert.False(result);
     }
@@ -285,12 +287,49 @@ public class StateManagerTests
         redisMock.Setup(r => r.CleanupStreamsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        var mgr = new StateManager(redisMock.Object, new ScanShutdownService(), NullLogger<StateManager>.Instance);
+        var mgr = new StateManager(redisMock.Object, new ScanShutdownService(), Mock.Of<IScanProgress>(), NullLogger<StateManager>.Instance);
         Assert.False(mgr.Token.IsCancellationRequested);
 
-        await mgr.ShutdownAsync("exec-123", "completed");
+        await mgr.ShutdownAsync("exec-123", ScanStatus.Completed);
 
         Assert.True(mgr.Token.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task Shutdown_Failed_CallsUpdateExecutionAsync_WithFailedStatus()
+    {
+        var progressMock = new Mock<IScanProgress>();
+        var mgr = CreateManager(progressMock: progressMock);
+
+        await mgr.ShutdownAsync("exec-123", ScanStatus.Failed);
+
+        progressMock.Verify(p => p.UpdateExecutionAsync(
+            ScanStatus.Failed, null, null, It.IsAny<DateTimeOffset?>(), 0, default), Times.Once);
+    }
+
+    [Fact]
+    public async Task Shutdown_Completed_CallsUpdateExecutionAsync_WithNonNullCompletedAt()
+    {
+        var progressMock = new Mock<IScanProgress>();
+        var mgr = CreateManager(progressMock: progressMock);
+
+        await mgr.ShutdownAsync("exec-123", ScanStatus.Completed);
+
+        progressMock.Verify(p => p.UpdateExecutionAsync(
+            ScanStatus.Completed, null, null, It.IsNotNull<DateTimeOffset?>(), 0, default), Times.Once);
+    }
+
+    [Fact]
+    public async Task Shutdown_Paused_CallsUpdateExecutionAsync_WithNullCompletedAt()
+    {
+        var progressMock = new Mock<IScanProgress>();
+        var mgr = CreateManager(progressMock: progressMock);
+        await mgr.SetStateAsync(ScanStatus.Pausing);
+
+        await mgr.ShutdownAsync("exec-123", ScanStatus.Paused);
+
+        progressMock.Verify(p => p.UpdateExecutionAsync(
+            ScanStatus.Paused, null, null, null, 0, default), Times.Once);
     }
 
     // ── Dispose ───────────────────────────────────────────────────────────

--- a/template/netwrix-csharp/ConnectorFramework/AACorePlatformFacade.cs
+++ b/template/netwrix-csharp/ConnectorFramework/AACorePlatformFacade.cs
@@ -1,27 +1,27 @@
 using System.Text;
 using System.Text.Json;
-using Netwrix.ConnectorFramework;
+using System.Text.Json.Nodes;
 using Netwrix.Overlord.Sdk.Cloud;
 using Netwrix.Overlord.Sdk.Cloud.TaskScheduler.Models;
 using Netwrix.Overlord.Sdk.Core.Activity.Models;
 using Netwrix.Overlord.Sdk.Core.State.Models;
 
-namespace Netwrix.Connector;
+namespace Netwrix.ConnectorFramework;
 
-public class AACorePlatformFacade : ICorePlatformFacade
+public sealed class AACorePlatformFacade : ICorePlatformFacade
 {
-    protected readonly ILogger _logger;
-    protected readonly IHttpClientFactory _httpClientFactory;
-    protected readonly FunctionContext FunctionContext;
+    private const string ObjectsTable = "objects";
+    private const string ActivityRecordsTable = "activity_records";
 
-    public AACorePlatformFacade(
-        ILogger<AACorePlatformFacade> logger,
-        IHttpClientFactory httpClientFactory,
-        FunctionContext functionContext)
+    private readonly ILogger<AACorePlatformFacade> _logger;
+    private readonly IScanWriter _writer;
+
+    public AACorePlatformFacade(ILogger<AACorePlatformFacade> logger, IScanWriter writer)
     {
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(writer);
         _logger = logger;
-        _httpClientFactory = httpClientFactory;
-        FunctionContext = functionContext;
+        _writer = writer;
     }
 
     /// <summary>
@@ -33,6 +33,20 @@ public class AACorePlatformFacade : ICorePlatformFacade
         var payloadObject = JsonSerializer.Deserialize<TData>(payloadString);
         return Task.FromResult(payloadObject
             ?? throw new InvalidOperationException("Unable to deserialize data payload."));
+    }
+
+    public async Task UploadSiTSchemaRecords(CrawlContext context, string tableName, IReadOnlyList<JsonObject> entities, bool isFinal,
+        int chunkId = 1)
+    {
+        foreach (var entity in entities)
+        {
+            _writer.SaveObject(tableName, entity);
+        }
+
+        if (isFinal)
+        {
+            await _writer.FlushTablesAsync(CancellationToken.None);
+        }
     }
 
     /// <summary>
@@ -53,17 +67,16 @@ public class AACorePlatformFacade : ICorePlatformFacade
 
     public Task UploadActivityRecords(List<ActivityRecord> activityRecords)
     {
-        // Activity upload not implemented for Access Analyzer connector.
-        // TODO T2: Implement or document as intentionally unsupported with NotSupportedException.
+        foreach (var record in activityRecords)
+        {
+            _writer.SaveObject(ActivityRecordsTable, record);
+        }
+
         return Task.CompletedTask;
     }
 
     /// <summary>
     /// Uploads SiT (State in Time) records to the core platform.
-    ///
-    /// NOTE: The object-type label map (Guid to type name) is connector-specific and must be
-    /// added by the connector developer in their own project — do not add it to the template.
-    /// See TODO T10.
     /// </summary>
     public async Task UploadSiTRecords(
         CrawlContext context,
@@ -73,24 +86,7 @@ public class AACorePlatformFacade : ICorePlatformFacade
         bool isFinal,
         int chunkId = 1)
     {
-        using var activity = FunctionContext.StartActivity("upload-sit-records");
-
-        foreach (var obj in objectModels)
-        {
-            _logger.LogInformation("Object {Type} {Count} properties",
-                obj.Type, obj.Properties?.Count ?? 0);
-            FunctionContext.GetTable("objects").AddObject(obj);
-        }
-
-        // TODO T1: Implement mapping model upload — FunctionContext.GetTable("mapping").AddObject(m)
-        // TODO T1: Implement action model upload  — FunctionContext.GetTable("action").AddObject(a)
-
-        if (isFinal)
-        {
-            _logger.LogInformation("Final upload — flushing all pending batches");
-            // CancellationToken.None is intentional: a final flush must not be abandoned even
-            // if the scan has been cancelled — data already buffered must reach the ingestion service.
-            await FunctionContext.FlushTablesAsync(CancellationToken.None);
-        }
+        throw new NotSupportedException(
+            "Upload of graph based State in Time Records is not supported in Access Analyzer connectors.");
     }
 }

--- a/template/netwrix-csharp/ConnectorFramework/AACorePlatformFacade.cs
+++ b/template/netwrix-csharp/ConnectorFramework/AACorePlatformFacade.cs
@@ -78,7 +78,7 @@ public sealed class AACorePlatformFacade : ICorePlatformFacade
     /// <summary>
     /// Uploads SiT (State in Time) records to the core platform.
     /// </summary>
-    public async Task UploadSiTRecords(
+    public Task UploadSiTRecords(
         CrawlContext context,
         List<SitObjectImportModel> objectModels,
         List<SitMappingImportModel> mappingModels,

--- a/template/netwrix-csharp/ConnectorFramework/AACorePlatformFacade.cs
+++ b/template/netwrix-csharp/ConnectorFramework/AACorePlatformFacade.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using System.Text.Json;
-using Microsoft.Extensions.Logging;
 using Netwrix.ConnectorFramework;
 using Netwrix.Overlord.Sdk.Cloud;
 using Netwrix.Overlord.Sdk.Cloud.TaskScheduler.Models;
@@ -89,7 +88,9 @@ public class AACorePlatformFacade : ICorePlatformFacade
         if (isFinal)
         {
             _logger.LogInformation("Final upload — flushing all pending batches");
-            await FunctionContext.FlushTablesAsync();
+            // CancellationToken.None is intentional: a final flush must not be abandoned even
+            // if the scan has been cancelled — data already buffered must reach the ingestion service.
+            await FunctionContext.FlushTablesAsync(CancellationToken.None);
         }
     }
 }

--- a/template/netwrix-csharp/ConnectorFramework/AACorePlatformFacade.cs
+++ b/template/netwrix-csharp/ConnectorFramework/AACorePlatformFacade.cs
@@ -10,7 +10,7 @@ namespace Netwrix.ConnectorFramework;
 
 public sealed class AACorePlatformFacade : ICorePlatformFacade
 {
-    private const string ActivityRecordsTable = "activity_records";
+    // private const string ActivityRecordsTable = "activity_records";
 
     private readonly ILogger<AACorePlatformFacade> _logger;
     private readonly IScanWriter _writer;
@@ -66,10 +66,11 @@ public sealed class AACorePlatformFacade : ICorePlatformFacade
 
     public Task UploadActivityRecords(List<ActivityRecord> activityRecords)
     {
-        foreach (var record in activityRecords)
-        {
-            _writer.SaveObject(ActivityRecordsTable, record);
-        }
+        // TODO: re-enable once we have the activity record schema in clickhouse.
+        // foreach (var record in activityRecords)
+        // {
+        //     _writer.SaveObject(ActivityRecordsTable, record);
+        // }
 
         return Task.CompletedTask;
     }

--- a/template/netwrix-csharp/ConnectorFramework/AACorePlatformFacade.cs
+++ b/template/netwrix-csharp/ConnectorFramework/AACorePlatformFacade.cs
@@ -10,7 +10,6 @@ namespace Netwrix.ConnectorFramework;
 
 public sealed class AACorePlatformFacade : ICorePlatformFacade
 {
-    private const string ObjectsTable = "objects";
     private const string ActivityRecordsTable = "activity_records";
 
     private readonly ILogger<AACorePlatformFacade> _logger;

--- a/template/netwrix-csharp/ConnectorFramework/AACrawlTaskCorePlatformFacade.cs
+++ b/template/netwrix-csharp/ConnectorFramework/AACrawlTaskCorePlatformFacade.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using Microsoft.Extensions.Logging;
 using Netwrix.ConnectorFramework;
 using Netwrix.Overlord.Sdk.Cloud.TaskScheduler;
 using Netwrix.Overlord.Sdk.Cloud.TaskScheduler.Models;

--- a/template/netwrix-csharp/ConnectorFramework/AACrawlTaskCorePlatformFacade.cs
+++ b/template/netwrix-csharp/ConnectorFramework/AACrawlTaskCorePlatformFacade.cs
@@ -1,32 +1,69 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using Netwrix.ConnectorFramework;
+using System.Text.Json.Nodes;
+using Netwrix.Overlord.Sdk.Cloud;
 using Netwrix.Overlord.Sdk.Cloud.TaskScheduler;
 using Netwrix.Overlord.Sdk.Cloud.TaskScheduler.Models;
 using Netwrix.Overlord.Sdk.Cloud.TaskScheduler.Models.Api;
+using Netwrix.Overlord.Sdk.Core.Activity.Models;
+using Netwrix.Overlord.Sdk.Core.State.Models;
 
-namespace Netwrix.Connector;
+namespace Netwrix.ConnectorFramework;
 
-public class AACrawlTaskCorePlatformFacade : AACorePlatformFacade, ICrawlTaskManagementPlatformFacade
+public sealed class AACrawlTaskCorePlatformFacade : ICorePlatformFacade, ICrawlTaskManagementPlatformFacade
 {
     private const int MaxUpdateIntervalMinutes = 5;
+
+    private readonly AACorePlatformFacade _core;
+    private readonly IScanProgress _progress;
+    private readonly ILogger<AACrawlTaskCorePlatformFacade> _logger;
 
     private readonly ConcurrentQueue<ApiChildCrawlTask> _crawlTaskQueue = new();
     private readonly ConcurrentDictionary<Guid, int> _processedItems = new();
     private readonly ConcurrentDictionary<Guid, int> _processedErrors = new();
     private int _reportedItemsCount;
     private long _lastUpdateTimestamp = Stopwatch.GetTimestamp();
+    // CAS guard: 0 = idle, 1 = updating. Prevents two concurrent callers from both
+    // passing the throttle check and issuing duplicate progress updates.
+    private int _updateGuard;
 
     private CrawlTaskConfiguration.SourcePayload? _sourcePayload;
     private List<CrawlTaskConfiguration.ConnectorConfigPayload>? _connectorConfigs;
 
     public AACrawlTaskCorePlatformFacade(
-        ILogger<AACrawlTaskCorePlatformFacade> logger,
-        IHttpClientFactory httpClientFactory,
-        FunctionContext functionContext)
-        : base(logger, httpClientFactory, functionContext)
+        AACorePlatformFacade core,
+        IScanProgress progress,
+        ILogger<AACrawlTaskCorePlatformFacade> logger)
     {
+        ArgumentNullException.ThrowIfNull(core);
+        ArgumentNullException.ThrowIfNull(progress);
+        ArgumentNullException.ThrowIfNull(logger);
+        _core = core;
+        _progress = progress;
+        _logger = logger;
     }
+
+    // ── ICorePlatformFacade — delegate to _core ───────────────────────────────
+
+    public Task<TData> DecryptData<TData>(byte[] encryptedKey, byte[] encryptedPayload)
+        => _core.DecryptData<TData>(encryptedKey, encryptedPayload);
+
+    public Task<TData> DecryptTenancyData<TData>(byte[] encryptedKey, byte[] encryptedPayload)
+        => _core.DecryptTenancyData<TData>(encryptedKey, encryptedPayload);
+
+    public Task<TMessage> DecryptServiceBusMessage<TMessage>(string message)
+        => _core.DecryptServiceBusMessage<TMessage>(message);
+
+    public Task UploadSiTSchemaRecords(CrawlContext context, string tableName, IReadOnlyList<JsonObject> entities, bool isFinal, int chunkId = 1)
+        => _core.UploadSiTSchemaRecords(context, tableName, entities, isFinal, chunkId);
+
+    public Task UploadSiTRecords(CrawlContext context, List<SitObjectImportModel> objectModels, List<SitMappingImportModel> mappingModels, List<SitImportActionModel> actionModels, bool isFinal, int chunkId = 1)
+        => _core.UploadSiTRecords(context, objectModels, mappingModels, actionModels, isFinal, chunkId);
+
+    public Task UploadActivityRecords(List<ActivityRecord> activityRecords)
+        => _core.UploadActivityRecords(activityRecords);
+
+    // ── ICrawlTaskManagementPlatformFacade ────────────────────────────────────
 
     /// <summary>
     /// Exposes the queue of child crawl tasks enqueued during <see cref="FinaliseTask"/>.
@@ -80,13 +117,19 @@ public class AACrawlTaskCorePlatformFacade : AACorePlatformFacade, ICrawlTaskMan
             return;
         }
 
+        // CAS guard: if another caller already claimed the update slot, skip.
+        if (Interlocked.CompareExchange(ref _updateGuard, 1, 0) != 0)
+        {
+            return;
+        }
+
         try
         {
-            using var activity = FunctionContext.StartActivity("update-execution-progress");
+            using var activity = _progress.StartActivity("update-execution-progress");
             var totalItems = _processedItems.Values.Sum();
             var delta = totalItems - _reportedItemsCount;
-            await FunctionContext.UpdateExecutionAsync(
-                status: "running",
+            await _progress.UpdateExecutionAsync(
+                status: ScanStatus.Running,
                 incrementCompletedObjects: delta);
             _reportedItemsCount = totalItems;
             _lastUpdateTimestamp = Stopwatch.GetTimestamp();
@@ -95,12 +138,19 @@ public class AACrawlTaskCorePlatformFacade : AACorePlatformFacade, ICrawlTaskMan
         {
             _logger.LogWarning(ex, "Unable to perform regular task update for task {TaskReference}", taskReference);
         }
+        finally
+        {
+            Interlocked.Exchange(ref _updateGuard, 0);
+        }
     }
 
     public Task FinaliseTask(APICrawlTaskProgress taskProgress)
     {
         if (taskProgress.ChildTasks is null)
         {
+            _logger.LogDebug(
+                "FinaliseTask: no child tasks for {CrawlTaskReference} — nothing to enqueue",
+                taskProgress.CrawlTaskReference);
             return Task.CompletedTask;
         }
 
@@ -119,24 +169,32 @@ public class AACrawlTaskCorePlatformFacade : AACorePlatformFacade, ICrawlTaskMan
             _crawlTaskQueue.Enqueue(childTask);
         }
 
+        // Remove the finalized task's entries to prevent unbounded memory growth
+        // on long-running connectors with many child tasks.
+        _processedItems.TryRemove(taskProgress.CrawlTaskReference, out _);
+        _processedErrors.TryRemove(taskProgress.CrawlTaskReference, out _);
+
         return Task.CompletedTask;
     }
 
     public async Task FinalizeScan()
     {
+        using var activity = _progress.StartActivity("finalize-scan");
+        var totalItems = _processedItems.Values.Sum();
+        var delta = totalItems - _reportedItemsCount;
         try
         {
-            using var activity = FunctionContext.StartActivity("finalize-scan");
-            var totalItems = _processedItems.Values.Sum();
-            var delta = totalItems - _reportedItemsCount;
-            await FunctionContext.UpdateExecutionAsync(
-                status: "completed",
+            await _progress.UpdateExecutionAsync(
+                status: ScanStatus.Completed,
                 incrementCompletedObjects: delta);
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Unable to finalize scan status {ScanExecutionId}",
-                FunctionContext.ScanExecutionId);
+                _progress.Execution.ScanExecutionId);
+            // Rethrow so the job runner can set execution status to Failed
+            // rather than silently completing with an unknown status.
+            throw;
         }
     }
 }

--- a/template/netwrix-csharp/ConnectorFramework/BackgroundScope.cs
+++ b/template/netwrix-csharp/ConnectorFramework/BackgroundScope.cs
@@ -1,5 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
-
 namespace Netwrix.ConnectorFramework;
 
 /// <summary>
@@ -20,8 +18,11 @@ internal sealed class RequestDataHolder
         set
         {
             if (_data is not null)
+            {
                 throw new InvalidOperationException(
                     "RequestDataHolder.Data may only be set once per scope.");
+            }
+
             _data = value;
         }
     }

--- a/template/netwrix-csharp/ConnectorFramework/BatchManager.cs
+++ b/template/netwrix-csharp/ConnectorFramework/BatchManager.cs
@@ -16,8 +16,9 @@ public sealed class BatchManager : IAsyncDisposable
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ConnectorRequestData _requestData;
     private readonly ILogger<BatchManager> _logger;
+    private readonly Func<int, CancellationToken, Task>? _onFlushed;
 
-    private readonly Channel<byte[]> _flushChannel;
+    private readonly Channel<(byte[] Data, int Count)> _flushChannel;
     private readonly Task _flushWorker;
 
     // Single-writer guarantee: AddObject is called from the connector's scan loop, never concurrently per table.
@@ -29,16 +30,18 @@ public sealed class BatchManager : IAsyncDisposable
         string tableName,
         IHttpClientFactory httpClientFactory,
         ConnectorRequestData requestData,
-        ILogger<BatchManager> logger)
+        ILogger<BatchManager> logger,
+        Func<int, CancellationToken, Task>? onFlushed = null)
     {
         _tableName = tableName;
         _httpClientFactory = httpClientFactory;
         _requestData = requestData;
         _logger = logger;
+        _onFlushed = onFlushed;
 
         _buffer = NewBuffer();
 
-        _flushChannel = Channel.CreateUnbounded<byte[]>(new UnboundedChannelOptions
+        _flushChannel = Channel.CreateUnbounded<(byte[], int)>(new UnboundedChannelOptions
         {
             SingleReader = true,
             SingleWriter = true,
@@ -53,7 +56,9 @@ public sealed class BatchManager : IAsyncDisposable
     /// Adds an object to the buffer. If the buffer exceeds 500 KB, an async flush is triggered.
     /// This method is synchronous — it never performs I/O.
     /// </summary>
-    public void AddObject(object obj)
+    /// <param name="obj">The object to add.</param>
+    /// <param name="updateStatus">When true (default), counts this object for completion reporting.</param>
+    public void AddObject(object obj, bool updateStatus = true)
     {
         if (obj is null)
         {
@@ -84,7 +89,10 @@ public sealed class BatchManager : IAsyncDisposable
 
             _buffer.Write(enhancedBytes);
             _buffer.WriteByte((byte)',');
-            _pendingObjectCount++;
+            if (updateStatus)
+            {
+                _pendingObjectCount++;
+            }
         }
         finally
         {
@@ -123,12 +131,12 @@ public sealed class BatchManager : IAsyncDisposable
         return ms;
     }
 
-    private byte[] FinaliseBuffer()
+    private (byte[] Data, int Count) FinaliseBuffer()
     {
         // _buffer.ToArray() returns a new copy — safe to mutate the trailing comma to ']'
         var result = _buffer.ToArray();
         result[^1] = (byte)']';
-        return result;
+        return (result, _pendingObjectCount);
     }
 
     private byte[] BuildEnhancedObject(object obj)
@@ -155,13 +163,13 @@ public sealed class BatchManager : IAsyncDisposable
 
     private async Task RunFlushWorkerAsync()
     {
-        await foreach (var payload in _flushChannel.Reader.ReadAllAsync())
+        await foreach (var (payload, count) in _flushChannel.Reader.ReadAllAsync())
         {
-            await PostBatchAsync(payload);
+            await PostBatchAsync(payload, count);
         }
     }
 
-    private async Task PostBatchAsync(byte[] dataArray)
+    private async Task PostBatchAsync(byte[] dataArray, int count)
     {
         var sourceType = Environment.GetEnvironmentVariable("SOURCE_TYPE") ?? "";
 
@@ -195,7 +203,14 @@ public sealed class BatchManager : IAsyncDisposable
 
             var response = await client.SendAsync(request);
 
-            if (!response.IsSuccessStatusCode)
+            if (response.IsSuccessStatusCode)
+            {
+                if (_onFlushed is not null && count > 0)
+                {
+                    await _onFlushed(count, CancellationToken.None);
+                }
+            }
+            else
             {
                 _logger.LogWarning("Batch flush returned {StatusCode} for table {Table}", (int)response.StatusCode, _tableName);
             }

--- a/template/netwrix-csharp/ConnectorFramework/BatchManager.cs
+++ b/template/netwrix-csharp/ConnectorFramework/BatchManager.cs
@@ -141,15 +141,12 @@ public sealed class BatchManager : IAsyncDisposable
         return (result, _pendingObjectCount);
     }
 
-    private byte[] BuildEnhancedObject(object obj)
+    private static byte[] BuildEnhancedObject(object obj)
     {
         using var ms = new MemoryStream();
         using var writer = new Utf8JsonWriter(ms);
 
         writer.WriteStartObject();
-        writer.WriteString("scan_id", _requestData.Execution.ScanId ?? "");
-        writer.WriteString("scan_execution_id", _requestData.Execution.ScanExecutionId ?? "");
-        writer.WriteString("scanned_at", DateTimeOffset.UtcNow.ToString("O"));
 
         // Copy the connector object's properties after the injected framework fields
         using var doc = JsonSerializer.SerializeToDocument(obj);

--- a/template/netwrix-csharp/ConnectorFramework/BatchManager.cs
+++ b/template/netwrix-csharp/ConnectorFramework/BatchManager.cs
@@ -18,7 +18,7 @@ public sealed class BatchManager : IAsyncDisposable
     private readonly ILogger<BatchManager> _logger;
     private readonly Func<int, CancellationToken, Task>? _onFlushed;
 
-    private readonly Channel<(byte[] Data, int Count)> _flushChannel;
+    private readonly Channel<(byte[] Data, int Count, CancellationToken Ct)> _flushChannel;
     private readonly Task _flushWorker;
 
     // Single-writer guarantee: AddObject is called from the connector's scan loop, never concurrently per table.
@@ -41,7 +41,7 @@ public sealed class BatchManager : IAsyncDisposable
 
         _buffer = NewBuffer();
 
-        _flushChannel = Channel.CreateUnbounded<(byte[], int)>(new UnboundedChannelOptions
+        _flushChannel = Channel.CreateUnbounded<(byte[], int, CancellationToken)>(new UnboundedChannelOptions
         {
             SingleReader = true,
             SingleWriter = true,
@@ -78,7 +78,8 @@ public sealed class BatchManager : IAsyncDisposable
             if (_buffer.Length + enhancedBytes.Length > ThresholdBytes && _buffer.Length > 1)
             {
                 var snapshot = FinaliseBuffer();
-                if (!_flushChannel.Writer.TryWrite(snapshot))
+                // AddObject has no ct — batches auto-enqueued mid-scan use None.
+                if (!_flushChannel.Writer.TryWrite((snapshot.Data, snapshot.Count, CancellationToken.None)))
                 {
                     _logger.LogError("Failed to enqueue batch for table {Table} — channel is closed", _tableName);
                 }
@@ -109,7 +110,8 @@ public sealed class BatchManager : IAsyncDisposable
         if (_buffer.Length > 1)
         {
             var snapshot = FinaliseBuffer();
-            if (!_flushChannel.Writer.TryWrite(snapshot))
+            // Propagate ct so the _onFlushed callback (progress reporting) respects cancellation.
+            if (!_flushChannel.Writer.TryWrite((snapshot.Data, snapshot.Count, ct)))
             {
                 _logger.LogError("Failed to enqueue final batch for table {Table} — channel is closed", _tableName);
             }
@@ -145,8 +147,8 @@ public sealed class BatchManager : IAsyncDisposable
         using var writer = new Utf8JsonWriter(ms);
 
         writer.WriteStartObject();
-        writer.WriteString("scan_id", _requestData.ScanId ?? "");
-        writer.WriteString("scan_execution_id", _requestData.ScanExecutionId ?? "");
+        writer.WriteString("scan_id", _requestData.Execution.ScanId ?? "");
+        writer.WriteString("scan_execution_id", _requestData.Execution.ScanExecutionId ?? "");
         writer.WriteString("scanned_at", DateTimeOffset.UtcNow.ToString("O"));
 
         // Copy the connector object's properties after the injected framework fields
@@ -157,19 +159,20 @@ public sealed class BatchManager : IAsyncDisposable
         }
 
         writer.WriteEndObject();
+        // Synchronous flush is safe here: the backing stream is an in-memory MemoryStream.
         writer.Flush();
         return ms.ToArray();
     }
 
     private async Task RunFlushWorkerAsync()
     {
-        await foreach (var (payload, count) in _flushChannel.Reader.ReadAllAsync())
+        await foreach (var (payload, count, ct) in _flushChannel.Reader.ReadAllAsync())
         {
-            await PostBatchAsync(payload, count);
+            await PostBatchAsync(payload, count, ct);
         }
     }
 
-    private async Task PostBatchAsync(byte[] dataArray, int count)
+    private async Task PostBatchAsync(byte[] dataArray, int count, CancellationToken ct)
     {
         var sourceType = Environment.GetEnvironmentVariable("SOURCE_TYPE") ?? "";
 
@@ -201,13 +204,13 @@ public sealed class BatchManager : IAsyncDisposable
                 request.Headers.TryAddWithoutValidation(k, v);
             }
 
-            var response = await client.SendAsync(request);
+            var response = await client.SendAsync(request, ct);
 
             if (response.IsSuccessStatusCode)
             {
                 if (_onFlushed is not null && count > 0)
                 {
-                    await _onFlushed(count, CancellationToken.None);
+                    await _onFlushed(count, ct);
                 }
             }
             else
@@ -223,14 +226,14 @@ public sealed class BatchManager : IAsyncDisposable
 
     private IEnumerable<KeyValuePair<string, string>> GetCallerHeaders()
     {
-        if (_requestData.ScanId is not null)
+        if (_requestData.Execution.ScanId is not null)
         {
-            yield return new("Scan-Id", _requestData.ScanId);
+            yield return new("Scan-Id", _requestData.Execution.ScanId);
         }
 
-        if (_requestData.ScanExecutionId is not null)
+        if (_requestData.Execution.ScanExecutionId is not null)
         {
-            yield return new("Scan-Execution-Id", _requestData.ScanExecutionId);
+            yield return new("Scan-Execution-Id", _requestData.Execution.ScanExecutionId);
         }
     }
 

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorFramework.csproj
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorFramework.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Netwrix.Overlord.Sdk.Cloud" Version="2.0.0.7-preview" />
-    <PackageReference Include="Netwrix.Overlord.Sdk.Core" Version="2.0.0.7-preview" />
+    <PackageReference Include="Netwrix.Overlord.Sdk.Cloud" Version="2.0.0.8-preview" />
+    <PackageReference Include="Netwrix.Overlord.Sdk.Core" Version="2.0.0.8-preview" />
     <PackageReference Include="Netwrix.UK.Core" Version="5.2.2.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.*" />
     <PackageReference Include="OpenTelemetry" Version="1.9.*" />

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorFramework.csproj
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorFramework.csproj
@@ -19,15 +19,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Netwrix.Overlord.Sdk.Cloud" Version="1.3.2.1" />
-    <PackageReference Include="Netwrix.Overlord.Sdk.Core" Version="1.3.2.1" />
+    <PackageReference Include="Netwrix.Overlord.Sdk.Cloud" Version="2.0.0.2-preview" />
+    <PackageReference Include="Netwrix.Overlord.Sdk.Core" Version="2.0.0.2-preview" />
     <PackageReference Include="Netwrix.UK.Core" Version="5.2.2.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.*" />
-    <PackageReference Include="OpenTelemetry" Version="1.10.*" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.*" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.*" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.10.*" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.*" />
+    <PackageReference Include="OpenTelemetry" Version="1.9.*" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.*" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.*" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.*" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.*" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.*" />
   </ItemGroup>
 

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorFramework.csproj
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorFramework.csproj
@@ -16,11 +16,14 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>FakeFs.Tests</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>ConnectorFramework.Tests</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Netwrix.Overlord.Sdk.Cloud" Version="2.0.0.2-preview" />
-    <PackageReference Include="Netwrix.Overlord.Sdk.Core" Version="2.0.0.2-preview" />
+    <PackageReference Include="Netwrix.Overlord.Sdk.Cloud" Version="2.0.0.7-preview" />
+    <PackageReference Include="Netwrix.Overlord.Sdk.Core" Version="2.0.0.7-preview" />
     <PackageReference Include="Netwrix.UK.Core" Version="5.2.2.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.*" />
     <PackageReference Include="OpenTelemetry" Version="1.9.*" />
@@ -29,6 +32,10 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.*" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.*" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.*" />
+    <!-- Pin to 9.0.x so ConnectorFramework.deps.json satisfies connectors that require System.Text.Json 9.0.0.0 -->
+    <PackageReference Include="System.Text.Json" Version="9.0.*" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.*" />
+    <PackageReference Include="System.IO.Pipelines" Version="9.0.*" />
   </ItemGroup>
 
 </Project>

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorFramework.csproj
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorFramework.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Netwrix.Overlord.Sdk.Cloud" Version="2.0.0.8-preview" />
-    <PackageReference Include="Netwrix.Overlord.Sdk.Core" Version="2.0.0.8-preview" />
+    <PackageReference Include="Netwrix.Overlord.Sdk.Cloud" Version="2.0.0.12-preview" />
+    <PackageReference Include="Netwrix.Overlord.Sdk.Core" Version="2.0.0.12-preview" />
     <PackageReference Include="Netwrix.UK.Core" Version="5.2.2.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.*" />
     <PackageReference Include="OpenTelemetry" Version="1.9.*" />

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorRequestData.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorRequestData.cs
@@ -14,22 +14,19 @@ public sealed class ConnectorRequestData
     public string Path { get; }
     public IReadOnlyDictionary<string, string> Headers { get; }
     public byte[]? Body { get; }
-    public string? ScanId { get; }
-    public string? ScanExecutionId { get; }
+    public ExecutionContext Execution { get; }
 
     public ConnectorRequestData(
         string Method,
         string Path,
         IReadOnlyDictionary<string, string> Headers,
         byte[]? Body,
-        string? ScanId,
-        string? ScanExecutionId)
+        ExecutionContext Execution)
     {
         this.Method = Method;
         this.Path = Path;
         this.Headers = Headers;
         this.Body = Body;
-        this.ScanId = ScanId;
-        this.ScanExecutionId = ScanExecutionId;
+        this.Execution = Execution;
     }
 }

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorStateStorage.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorStateStorage.cs
@@ -93,13 +93,6 @@ public sealed class ConnectorStateStorage : IStateStorage
             return false;
         }
 
-        var allState = await FetchAllStateAsync(cancellationToken);
-
-        if (!allState.ContainsKey(key))
-        {
-            return false;
-        }
-
         await DeleteStateAsync(new[] { key }, cancellationToken);
         return true;
     }

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorStateStorage.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorStateStorage.cs
@@ -3,21 +3,14 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Netwrix.Overlord.Sdk.Core.Storage;
 using Netwrix.Overlord.Sdk.Core.Storage.Exceptions;
-
 namespace Netwrix.ConnectorFramework;
 
 /// <summary>
 /// <see cref="IStateStorage"/> implementation backed by the connector-state HTTP service.
-/// Values are JSON-serialized and stored as strings. ETags are simulated via companion keys
-/// prefixed with <c>__etag__:</c>, which are invisible to callers.
+/// Values are JSON-serialized and stored as strings.
 /// </summary>
-/// <remarks>
-/// A TOCTOU window exists between the GET (read-for-compare) and the POST (write) in
-/// <see cref="SetIfMatchAsync{T}"/> — unavoidable without native CAS in the HTTP backend.
-/// </remarks>
 public sealed class ConnectorStateStorage : IStateStorage
 {
-    private const string EtagKeyPrefix = "__etag__:";
 
     private readonly ConnectorRequestData _request;
     private readonly IHttpClientFactory _httpClientFactory;
@@ -55,9 +48,8 @@ public sealed class ConnectorStateStorage : IStateStorage
         }
 
         var value = Deserialize<T>(key, json);
-        allState.TryGetValue(EtagKey(key), out var etag);
 
-        return new TryGetResult<T>(value, etag);
+        return new TryGetResult<T>(value);
     }
 
     public async Task SetAsync<T>(string key, T value, CancellationToken cancellationToken = default)
@@ -72,13 +64,8 @@ public sealed class ConnectorStateStorage : IStateStorage
         }
 
         var json = Serialize(key, value);
-        var newEtag = Guid.NewGuid().ToString("N");
 
-        await WriteStateAsync(new Dictionary<string, string>
-        {
-            [key] = json,
-            [EtagKey(key)] = newEtag,
-        }, cancellationToken);
+        await WriteStateAsync(new Dictionary<string, string> { [key] = json }, cancellationToken);
     }
 
     public async Task<string> SetIfMatchAsync<T>(string key, T value, string? expectedETag, CancellationToken cancellationToken = default)
@@ -91,38 +78,9 @@ public sealed class ConnectorStateStorage : IStateStorage
             throw new StateStorageException($"SetIfMatchAsync called but ScanId is null — cannot write state for key: {key}");
         }
 
-        var allState = await FetchAllStateAsync(cancellationToken);
-
-        allState.TryGetValue(key, out var existingJson);
-        allState.TryGetValue(EtagKey(key), out var currentEtag);
-
-        if (expectedETag is null)
-        {
-            // Caller asserts key must not yet exist.
-            if (existingJson is not null)
-            {
-                throw new StateChangedException(key, expectedETag: null, actualETag: currentEtag);
-            }
-        }
-        else
-        {
-            // Caller asserts key must exist with the given ETag.
-            if (existingJson is null || currentEtag != expectedETag)
-            {
-                throw new StateChangedException(key, expectedETag, currentEtag);
-            }
-        }
-
         var json = Serialize(key, value);
-        var newEtag = Guid.NewGuid().ToString("N");
-
-        await WriteStateAsync(new Dictionary<string, string>
-        {
-            [key] = json,
-            [EtagKey(key)] = newEtag,
-        }, cancellationToken);
-
-        return newEtag;
+        await WriteStateAsync(new Dictionary<string, string> { [key] = json }, cancellationToken);
+        return string.Empty;
     }
 
     public async Task<bool> DeleteAsync(string key, CancellationToken cancellationToken = default)
@@ -142,11 +100,7 @@ public sealed class ConnectorStateStorage : IStateStorage
             return false;
         }
 
-        var toDelete = allState.ContainsKey(EtagKey(key))
-            ? new[] { key, EtagKey(key) }
-            : new[] { key };
-
-        await DeleteStateAsync(toDelete, cancellationToken);
+        await DeleteStateAsync(new[] { key }, cancellationToken);
         return true;
     }
 
@@ -162,20 +116,14 @@ public sealed class ConnectorStateStorage : IStateStorage
 
         var allState = await FetchAllStateAsync(cancellationToken);
 
-        var userKeys = allState.Keys
-            .Where(k => !IsEtagKey(k) && MatchesPrefix(k, keyPrefix))
-            .ToList();
+        var toDelete = allState.Keys
+            .Where(k => MatchesPrefix(k, keyPrefix))
+            .ToArray();
 
-        if (userKeys.Count == 0)
+        if (toDelete.Length == 0)
         {
             return;
         }
-
-        var toDelete = userKeys
-            .SelectMany(k => new[] { k, EtagKey(k) })
-            .Where(allState.ContainsKey)
-            .Distinct()
-            .ToArray();
 
         await DeleteStateAsync(toDelete, cancellationToken);
     }
@@ -210,7 +158,7 @@ public sealed class ConnectorStateStorage : IStateStorage
         var allState = await FetchAllStateAsync(cancellationToken);
 
         foreach (var key in allState.Keys
-            .Where(k => !IsEtagKey(k) && MatchesPrefix(k, keyPrefix))
+            .Where(k => MatchesPrefix(k, keyPrefix))
             .Order(StringComparer.Ordinal))
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -444,10 +392,6 @@ public sealed class ConnectorStateStorage : IStateStorage
 
         return headers;
     }
-
-    private static string EtagKey(string key) => EtagKeyPrefix + key;
-
-    private static bool IsEtagKey(string key) => key.StartsWith(EtagKeyPrefix, StringComparison.Ordinal);
 
     private static bool MatchesPrefix(string key, string prefix)
     {

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorStateStorage.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorStateStorage.cs
@@ -33,7 +33,7 @@ public sealed class ConnectorStateStorage : IStateStorage
         _logger = logger;
     }
 
-    private string? ScanId => _request.ScanId;
+    private string? ScanId => _request.Execution.ScanId;
 
     // ── IStateStorage ────────────────────────────────────────────────────────
 
@@ -416,14 +416,14 @@ public sealed class ConnectorStateStorage : IStateStorage
     {
         var headers = new Dictionary<string, string>();
 
-        if (_request.ScanId is not null)
+        if (_request.Execution.ScanId is not null)
         {
-            headers["Scan-Id"] = _request.ScanId;
+            headers["Scan-Id"] = _request.Execution.ScanId;
         }
 
-        if (_request.ScanExecutionId is not null)
+        if (_request.Execution.ScanExecutionId is not null)
         {
-            headers["Scan-Execution-Id"] = _request.ScanExecutionId;
+            headers["Scan-Execution-Id"] = _request.Execution.ScanExecutionId;
         }
 
         headers["Function-Type"] = Environment.GetEnvironmentVariable("FUNCTION_TYPE") ?? "netwrix";

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorStateStorage.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorStateStorage.cs
@@ -1,0 +1,463 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Netwrix.Overlord.Sdk.Core.Storage;
+using Netwrix.Overlord.Sdk.Core.Storage.Exceptions;
+
+namespace Netwrix.ConnectorFramework;
+
+/// <summary>
+/// <see cref="IStateStorage"/> implementation backed by the connector-state HTTP service.
+/// Values are JSON-serialized and stored as strings. ETags are simulated via companion keys
+/// prefixed with <c>__etag__:</c>, which are invisible to callers.
+/// </summary>
+/// <remarks>
+/// A TOCTOU window exists between the GET (read-for-compare) and the POST (write) in
+/// <see cref="SetIfMatchAsync{T}"/> — unavoidable without native CAS in the HTTP backend.
+/// </remarks>
+public sealed class ConnectorStateStorage : IStateStorage
+{
+    private const string EtagKeyPrefix = "__etag__:";
+
+    private readonly ConnectorRequestData _request;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<ConnectorStateStorage> _logger;
+
+    public ConnectorStateStorage(
+        ConnectorRequestData request,
+        IHttpClientFactory httpClientFactory,
+        ILogger<ConnectorStateStorage> logger)
+    {
+        _request = request;
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    private string? ScanId => _request.ScanId;
+
+    // ── IStateStorage ────────────────────────────────────────────────────────
+
+    public async Task<TryGetResult<T>> TryGetAsync<T>(string key, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(key);
+
+        if (ScanId is null)
+        {
+            _logger.LogWarning("TryGetAsync called but ScanId is null — returning NotFound");
+            return TryGetResult<T>.NotFound;
+        }
+
+        var allState = await FetchAllStateAsync(cancellationToken);
+
+        if (!allState.TryGetValue(key, out var json))
+        {
+            return TryGetResult<T>.NotFound;
+        }
+
+        var value = Deserialize<T>(key, json);
+        allState.TryGetValue(EtagKey(key), out var etag);
+
+        return new TryGetResult<T>(value, etag);
+    }
+
+    public async Task SetAsync<T>(string key, T value, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(key);
+        ArgumentNullException.ThrowIfNull(value);
+
+        if (ScanId is null)
+        {
+            _logger.LogWarning("SetAsync called but ScanId is null — skipping");
+            return;
+        }
+
+        var json = Serialize(key, value);
+        var newEtag = Guid.NewGuid().ToString("N");
+
+        await WriteStateAsync(new Dictionary<string, string>
+        {
+            [key] = json,
+            [EtagKey(key)] = newEtag,
+        }, cancellationToken);
+    }
+
+    public async Task<string> SetIfMatchAsync<T>(string key, T value, string? expectedETag, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(key);
+        ArgumentNullException.ThrowIfNull(value);
+
+        if (ScanId is null)
+        {
+            throw new StateStorageException($"SetIfMatchAsync called but ScanId is null — cannot write state for key: {key}");
+        }
+
+        var allState = await FetchAllStateAsync(cancellationToken);
+
+        allState.TryGetValue(key, out var existingJson);
+        allState.TryGetValue(EtagKey(key), out var currentEtag);
+
+        if (expectedETag is null)
+        {
+            // Caller asserts key must not yet exist.
+            if (existingJson is not null)
+            {
+                throw new StateChangedException(key, expectedETag: null, actualETag: currentEtag);
+            }
+        }
+        else
+        {
+            // Caller asserts key must exist with the given ETag.
+            if (existingJson is null || currentEtag != expectedETag)
+            {
+                throw new StateChangedException(key, expectedETag, currentEtag);
+            }
+        }
+
+        var json = Serialize(key, value);
+        var newEtag = Guid.NewGuid().ToString("N");
+
+        await WriteStateAsync(new Dictionary<string, string>
+        {
+            [key] = json,
+            [EtagKey(key)] = newEtag,
+        }, cancellationToken);
+
+        return newEtag;
+    }
+
+    public async Task<bool> DeleteAsync(string key, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(key);
+
+        if (ScanId is null)
+        {
+            _logger.LogWarning("DeleteAsync called but ScanId is null — skipping");
+            return false;
+        }
+
+        var allState = await FetchAllStateAsync(cancellationToken);
+
+        if (!allState.ContainsKey(key))
+        {
+            return false;
+        }
+
+        var toDelete = allState.ContainsKey(EtagKey(key))
+            ? new[] { key, EtagKey(key) }
+            : new[] { key };
+
+        await DeleteStateAsync(toDelete, cancellationToken);
+        return true;
+    }
+
+    public async Task DeleteAllAsync(string keyPrefix, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(keyPrefix);
+
+        if (ScanId is null)
+        {
+            _logger.LogWarning("DeleteAllAsync called but ScanId is null — skipping");
+            return;
+        }
+
+        var allState = await FetchAllStateAsync(cancellationToken);
+
+        var userKeys = allState.Keys
+            .Where(k => !IsEtagKey(k) && MatchesPrefix(k, keyPrefix))
+            .ToList();
+
+        if (userKeys.Count == 0)
+        {
+            return;
+        }
+
+        var toDelete = userKeys
+            .SelectMany(k => new[] { k, EtagKey(k) })
+            .Where(allState.ContainsKey)
+            .Distinct()
+            .ToArray();
+
+        await DeleteStateAsync(toDelete, cancellationToken);
+    }
+
+    public IAsyncEnumerable<string> ListAllKeysAsync(string keyPrefix = "", CancellationToken cancellationToken = default)
+        => ListAllKeysCoreAsync(keyPrefix, cancellationToken);
+
+    public IAsyncEnumerable<string> ListKeysAsync(string keyPrefix, int depth = 1, CancellationToken cancellationToken = default)
+    {
+        // Validate eagerly: the interface contract says ArgumentOutOfRangeException is thrown by this
+        // method, not deferred to first enumeration (which is the normal async-iterator trap).
+        if (depth < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(depth), "depth must be >= 1.");
+        }
+
+        return ListKeysCoreAsync(keyPrefix, depth, cancellationToken);
+    }
+
+    // ── Async iterators ──────────────────────────────────────────────────────
+
+    private async IAsyncEnumerable<string> ListAllKeysCoreAsync(
+        string keyPrefix,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        if (ScanId is null)
+        {
+            _logger.LogWarning("ListAllKeysAsync called but ScanId is null — returning empty");
+            yield break;
+        }
+
+        var allState = await FetchAllStateAsync(cancellationToken);
+
+        foreach (var key in allState.Keys
+            .Where(k => !IsEtagKey(k) && MatchesPrefix(k, keyPrefix))
+            .Order(StringComparer.Ordinal))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return key;
+        }
+    }
+
+    private async IAsyncEnumerable<string> ListKeysCoreAsync(
+        string keyPrefix,
+        int depth,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var trimmedPrefix = keyPrefix.Trim('/');
+        var prefixSegments = string.IsNullOrEmpty(trimmedPrefix) ? 0 : trimmedPrefix.Count(c => c == '/') + 1;
+        var targetSlashCount = prefixSegments + depth - 1;
+
+        await foreach (var key in ListAllKeysCoreAsync(keyPrefix, cancellationToken).ConfigureAwait(false))
+        {
+            if (key.Count(c => c == '/') == targetSlashCount)
+            {
+                yield return key;
+            }
+        }
+    }
+
+    // ── HTTP helpers ─────────────────────────────────────────────────────────
+
+    private async Task<Dictionary<string, string>> FetchAllStateAsync(CancellationToken ct)
+    {
+        var serviceUrl = ServiceUrlHelper.Resolve("CONNECTOR_STATE_FUNCTION", "connector-state");
+        var url = $"{serviceUrl}?scanId={Uri.EscapeDataString(ScanId!)}";
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient("connector-state");
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            foreach (var (k, v) in BuildCallerHeaders())
+            {
+                request.Headers.TryAddWithoutValidation(k, v);
+            }
+
+            using var response = await client.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new StateStorageException($"connector-state GET returned {(int)response.StatusCode}");
+            }
+
+            var body = await response.Content.ReadAsStringAsync(ct);
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+
+            if (!root.TryGetProperty("success", out var successProp) || !successProp.GetBoolean())
+            {
+                var error = root.TryGetProperty("error", out var errProp) ? errProp.GetString() : "Unknown error";
+                throw new StateStorageException($"connector-state GET failed: {error}");
+            }
+
+            if (root.TryGetProperty("data", out var dataProp))
+            {
+                return dataProp.Deserialize<Dictionary<string, string>>() ?? new Dictionary<string, string>();
+            }
+
+            return new Dictionary<string, string>();
+        }
+        catch (StateStorageException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new StateStorageException($"connector-state GET failed for scan {ScanId}", ex);
+        }
+    }
+
+    private async Task WriteStateAsync(Dictionary<string, string> data, CancellationToken ct)
+    {
+        var serviceUrl = ServiceUrlHelper.Resolve("CONNECTOR_STATE_FUNCTION", "connector-state");
+        var payload = new { scanId = ScanId, data };
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient("connector-state");
+            using var request = new HttpRequestMessage(HttpMethod.Post, serviceUrl)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(payload), System.Text.Encoding.UTF8, "application/json"),
+            };
+            foreach (var (k, v) in BuildCallerHeaders())
+            {
+                request.Headers.TryAddWithoutValidation(k, v);
+            }
+
+            using var response = await client.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new StateStorageException($"connector-state POST returned {(int)response.StatusCode}");
+            }
+
+            var body = await response.Content.ReadAsStringAsync(ct);
+            if (!string.IsNullOrWhiteSpace(body))
+            {
+                using var doc = JsonDocument.Parse(body);
+                var root = doc.RootElement;
+                if (root.TryGetProperty("success", out var successProp) && !successProp.GetBoolean())
+                {
+                    var error = root.TryGetProperty("error", out var errProp) ? errProp.GetString() : "Unknown error";
+                    throw new StateStorageException($"connector-state POST failed: {error}");
+                }
+            }
+        }
+        catch (StateStorageException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new StateStorageException($"connector-state POST failed for scan {ScanId}", ex);
+        }
+    }
+
+    private async Task DeleteStateAsync(string[] names, CancellationToken ct)
+    {
+        var serviceUrl = ServiceUrlHelper.Resolve("CONNECTOR_STATE_FUNCTION", "connector-state");
+        var qs = $"?scanId={Uri.EscapeDataString(ScanId!)}";
+        qs += string.Concat(names.Select(n => $"&name[]={Uri.EscapeDataString(n)}"));
+        var url = serviceUrl + qs;
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient("connector-state");
+            using var request = new HttpRequestMessage(HttpMethod.Delete, url);
+            foreach (var (k, v) in BuildCallerHeaders())
+            {
+                request.Headers.TryAddWithoutValidation(k, v);
+            }
+
+            using var response = await client.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new StateStorageException($"connector-state DELETE returned {(int)response.StatusCode}");
+            }
+
+            var body = await response.Content.ReadAsStringAsync(ct);
+            if (!string.IsNullOrWhiteSpace(body))
+            {
+                using var doc = JsonDocument.Parse(body);
+                var root = doc.RootElement;
+                if (root.TryGetProperty("success", out var successProp) && !successProp.GetBoolean())
+                {
+                    var error = root.TryGetProperty("error", out var errProp) ? errProp.GetString() : "Unknown error";
+                    throw new StateStorageException($"connector-state DELETE failed: {error}");
+                }
+            }
+        }
+        catch (StateStorageException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new StateStorageException($"connector-state DELETE failed for scan {ScanId}", ex);
+        }
+    }
+
+    // ── Serialization ────────────────────────────────────────────────────────
+
+    private static T Deserialize<T>(string key, string json)
+    {
+        try
+        {
+            var value = JsonSerializer.Deserialize<T>(json);
+            if (value is null)
+            {
+                throw new StateStorageException($"Deserialization returned null for key: {key}");
+            }
+
+            return value!;
+        }
+        catch (StateStorageException)
+        {
+            throw;
+        }
+        catch (JsonException ex)
+        {
+            throw new StateStorageException($"Failed to deserialize state at key: {key}", ex);
+        }
+    }
+
+    private static string Serialize<T>(string key, T value)
+    {
+        try
+        {
+            return JsonSerializer.Serialize(value);
+        }
+        catch (JsonException ex)
+        {
+            throw new StateStorageException($"Failed to serialize state for key: {key}", ex);
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private Dictionary<string, string> BuildCallerHeaders()
+    {
+        var headers = new Dictionary<string, string>();
+
+        if (_request.ScanId is not null)
+        {
+            headers["Scan-Id"] = _request.ScanId;
+        }
+
+        if (_request.ScanExecutionId is not null)
+        {
+            headers["Scan-Execution-Id"] = _request.ScanExecutionId;
+        }
+
+        headers["Function-Type"] = Environment.GetEnvironmentVariable("FUNCTION_TYPE") ?? "netwrix";
+
+        var current = Activity.Current;
+        if (current is not null)
+        {
+            if (current.Id is not null)
+            {
+                headers["traceparent"] = current.Id;
+            }
+
+            if (!string.IsNullOrEmpty(current.TraceStateString))
+            {
+                headers["tracestate"] = current.TraceStateString;
+            }
+        }
+
+        return headers;
+    }
+
+    private static string EtagKey(string key) => EtagKeyPrefix + key;
+
+    private static bool IsEtagKey(string key) => key.StartsWith(EtagKeyPrefix, StringComparison.Ordinal);
+
+    private static bool MatchesPrefix(string key, string prefix)
+    {
+        if (string.IsNullOrEmpty(prefix))
+        {
+            return true;
+        }
+
+        var normalizedPrefix = prefix.TrimEnd('/');
+        return key == normalizedPrefix
+            || key.StartsWith(normalizedPrefix + "/", StringComparison.Ordinal);
+    }
+}

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorStateStorage.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorStateStorage.cs
@@ -334,7 +334,7 @@ public sealed class ConnectorStateStorage : IStateStorage
     {
         var serviceUrl = ServiceUrlHelper.Resolve("CONNECTOR_STATE_FUNCTION", "connector-state");
         var qs = $"?scanId={Uri.EscapeDataString(ScanId!)}";
-        qs += string.Concat(names.Select(n => $"&name[]={Uri.EscapeDataString(n)}"));
+        qs += string.Concat(names.Select(n => $"&name={Uri.EscapeDataString(n)}"));
         var url = serviceUrl + qs;
 
         try

--- a/template/netwrix-csharp/ConnectorFramework/ExecutionContext.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ExecutionContext.cs
@@ -1,0 +1,17 @@
+namespace Netwrix.ConnectorFramework;
+
+public sealed record ExecutionContext(
+    string? ScanId,
+    string? ScanExecutionId,
+    string? SourceId,
+    string? SourceType,
+    string? SourceVersion,
+    string? FunctionType
+)
+{
+    /// <summary>
+    /// Returns true for function types that run long enough to warrant status updates
+    /// (Running → Completed/Failed) during job execution.
+    /// </summary>
+    public bool IsLongRunning => FunctionType is "access-scan" or "sync";
+}

--- a/template/netwrix-csharp/ConnectorFramework/FunctionContext.cs
+++ b/template/netwrix-csharp/ConnectorFramework/FunctionContext.cs
@@ -8,7 +8,7 @@ namespace Netwrix.ConnectorFramework;
 /// Per-request context provided to every connector operation.
 /// Injected by the framework via DI (Scoped lifetime).
 /// </summary>
-public sealed class FunctionContext : IAsyncDisposable
+public sealed class FunctionContext : IScanWriter, IScanProgress, IAsyncDisposable
 {
     private static readonly ActivitySource ActivitySource = new("Netwrix.ConnectorFramework");
 
@@ -18,10 +18,11 @@ public sealed class FunctionContext : IAsyncDisposable
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, BatchManager> _tables = new();
     private readonly ILoggerFactory _loggerFactory;
     private readonly IStateStorage _stateStorage;
+    private readonly IDisposable? _logScope;
+    private bool _flushed;
 
     public ConnectorRequestData Request { get; }
-    public string? ScanId => Request.ScanId;
-    public string? ScanExecutionId => Request.ScanExecutionId;
+    public ExecutionContext Execution => Request.Execution;
 
     /// <summary>Structured logger with automatic scan-context enrichment.</summary>
     public ILogger Log => _logger;
@@ -43,6 +44,14 @@ public sealed class FunctionContext : IAsyncDisposable
         _logger = logger;
         _loggerFactory = loggerFactory;
         _stateStorage = stateStorage;
+        _logScope = _logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["scan_id"] = request.Execution.ScanId,
+            ["scan_execution_id"] = request.Execution.ScanExecutionId,
+            ["function_type"] = request.Execution.FunctionType,
+            ["source_type"] = request.Execution.SourceType,
+            ["source_id"] = request.Execution.SourceId,
+        });
     }
 
     // ── Secrets ───────────────────────────────────────────────────────────────
@@ -136,6 +145,7 @@ public sealed class FunctionContext : IAsyncDisposable
     /// </summary>
     public async Task FlushTablesAsync(CancellationToken ct = default)
     {
+        _flushed = true;
         foreach (var (_, bm) in _tables)
         {
             await bm.FlushAsync(ct);
@@ -160,18 +170,17 @@ public sealed class FunctionContext : IAsyncDisposable
     {
         var headers = new Dictionary<string, string>();
 
-        if (ScanId is not null)
+        if (Execution.ScanId is not null)
         {
-            headers["Scan-Id"] = ScanId;
+            headers["Scan-Id"] = Execution.ScanId;
         }
 
-        if (ScanExecutionId is not null)
+        if (Execution.ScanExecutionId is not null)
         {
-            headers["Scan-Execution-Id"] = ScanExecutionId;
+            headers["Scan-Execution-Id"] = Execution.ScanExecutionId;
         }
 
-        var functionType = Environment.GetEnvironmentVariable("FUNCTION_TYPE") ?? "netwrix";
-        headers["Function-Type"] = functionType;
+        headers["Function-Type"] = Execution.FunctionType ?? "netwrix";
 
         var current = Activity.Current;
         if (current is not null)
@@ -204,13 +213,13 @@ public sealed class FunctionContext : IAsyncDisposable
         int incrementCompletedObjects = 0,
         CancellationToken ct = default)
     {
-        if (ScanExecutionId is null)
+        if (Execution.ScanExecutionId is null)
         {
             _logger.LogWarning("UpdateExecutionAsync called but ScanExecutionId is null — skipping");
             return;
         }
 
-        var payload = new Dictionary<string, object> { ["executionId"] = ScanExecutionId };
+        var payload = new Dictionary<string, object> { ["executionId"] = Execution.ScanExecutionId };
         if (status is not null)
         {
             payload["status"] = status;
@@ -258,7 +267,7 @@ public sealed class FunctionContext : IAsyncDisposable
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "UpdateExecution failed for execution {ExecutionId}", ScanExecutionId);
+            _logger.LogError(ex, "UpdateExecution failed for execution {ExecutionId}", Execution.ScanExecutionId);
         }
     }
 
@@ -270,7 +279,7 @@ public sealed class FunctionContext : IAsyncDisposable
     /// </summary>
     public async Task<Dictionary<string, string>?> GetConnectorStateAsync(CancellationToken ct = default)
     {
-        if (ScanId is null)
+        if (Execution.ScanId is null)
         {
             _logger.LogWarning("GetConnectorStateAsync called but ScanId is null — skipping");
             return null;
@@ -289,9 +298,13 @@ public sealed class FunctionContext : IAsyncDisposable
             }
             return result;
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "GetConnectorState failed for scan {ScanId}", ScanId);
+            _logger.LogError(ex, "GetConnectorState failed for scan {ScanId}", Execution.ScanId);
             return null;
         }
     }
@@ -301,7 +314,7 @@ public sealed class FunctionContext : IAsyncDisposable
     /// </summary>
     public async Task SetConnectorStateAsync(Dictionary<string, object?> data, CancellationToken ct = default)
     {
-        if (ScanId is null)
+        if (Execution.ScanId is null)
         {
             _logger.LogWarning("SetConnectorStateAsync called but ScanId is null — skipping");
             return;
@@ -319,7 +332,7 @@ public sealed class FunctionContext : IAsyncDisposable
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "SetConnectorState failed for scan {ScanId}", ScanId);
+            _logger.LogError(ex, "SetConnectorState failed for scan {ScanId}", Execution.ScanId);
         }
     }
 
@@ -329,7 +342,7 @@ public sealed class FunctionContext : IAsyncDisposable
     /// </summary>
     public async Task DeleteConnectorStateAsync(string[]? names = null, CancellationToken ct = default)
     {
-        if (ScanId is null)
+        if (Execution.ScanId is null)
         {
             _logger.LogWarning("DeleteConnectorStateAsync called but ScanId is null — skipping");
             return;
@@ -351,7 +364,7 @@ public sealed class FunctionContext : IAsyncDisposable
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "DeleteConnectorState failed for scan {ScanId}", ScanId);
+            _logger.LogError(ex, "DeleteConnectorState failed for scan {ScanId}", Execution.ScanId);
         }
     }
 
@@ -366,8 +379,17 @@ public sealed class FunctionContext : IAsyncDisposable
             return null;
         }
 
+        // Guard: scanExecutionId originates from HTTP headers / env vars (attacker-controlled).
+        // Validate it is a well-formed GUID before interpolating into the query string.
+        if (!Guid.TryParse(scanExecutionId, out var parsedId))
+        {
+            _logger.LogWarning(
+                "GetPriorExecutionAsync: scanExecutionId is not a valid GUID format — skipping query");
+            return null;
+        }
+
         var serviceUrl = ServiceUrlHelper.Resolve("APP_DATA_QUERY_FUNCTION", "app-data-query");
-        var query = $"SELECT id, status, completed_objects FROM scan_executions WHERE id = '{scanExecutionId}' LIMIT 1";
+        var query = $"SELECT id, status, completed_objects FROM scan_executions WHERE id = '{parsedId}' LIMIT 1";
         var payload = new { query };
 
         try
@@ -445,15 +467,17 @@ public sealed class FunctionContext : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
+        _logScope?.Dispose();
         foreach (var (_, bm) in _tables)
         {
-            await bm.FlushAsync();
+            // Skip flush if FlushTablesAsync() was already called (e.g. by the job runner).
+            // Flushing again would post duplicate batches to the data-ingestion service.
+            if (!_flushed)
+            {
+                await bm.FlushAsync();
+            }
+
             await bm.DisposeAsync();
         }
     }
 }
-
-/// <summary>
-/// Represents a prior scan execution returned from the app-data-query service.
-/// </summary>
-public sealed record PriorExecution(string Id, string Status, int CompletedObjects);

--- a/template/netwrix-csharp/ConnectorFramework/FunctionContext.cs
+++ b/template/netwrix-csharp/ConnectorFramework/FunctionContext.cs
@@ -13,7 +13,6 @@ public sealed class FunctionContext : IAsyncDisposable
 
     private readonly IConfiguration _configuration;
     private readonly IHttpClientFactory _httpClientFactory;
-    private readonly RedisSignalHandler _redis;
     private readonly ILogger<FunctionContext> _logger;
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, BatchManager> _tables = new();
     private readonly ILoggerFactory _loggerFactory;
@@ -29,14 +28,12 @@ public sealed class FunctionContext : IAsyncDisposable
         ConnectorRequestData request,
         IConfiguration configuration,
         IHttpClientFactory httpClientFactory,
-        RedisSignalHandler redis,
         ILogger<FunctionContext> logger,
         ILoggerFactory loggerFactory)
     {
         Request = request;
         _configuration = configuration;
         _httpClientFactory = httpClientFactory;
-        _redis = redis;
         _logger = logger;
         _loggerFactory = loggerFactory;
     }
@@ -47,11 +44,12 @@ public sealed class FunctionContext : IAsyncDisposable
 
     /// <summary>
     /// Lazily loads secrets from /var/secrets/{name} (connector-api) or /var/openfaas/secrets/{name} (fallback).
+    /// Applies SECRET_MAPPINGS env var aliases after loading (format: "key1:secretName1,key2:secretName2").
     /// Access secrets via context.Secrets["my-secret"].
     /// </summary>
     public IReadOnlyDictionary<string, string> Secrets => _secrets ??= LoadSecrets();
 
-    private static IReadOnlyDictionary<string, string> LoadSecrets()
+    private IReadOnlyDictionary<string, string> LoadSecrets()
     {
         var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
@@ -79,6 +77,28 @@ public sealed class FunctionContext : IAsyncDisposable
             }
         }
 
+        // Apply SECRET_MAPPINGS aliases: "appKey1:secretFile1,appKey2:secretFile2"
+        var mappings = Environment.GetEnvironmentVariable("SECRET_MAPPINGS") ?? "";
+        foreach (var mapping in mappings.Split(',', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var parts = mapping.Split(':', 2);
+            if (parts.Length != 2)
+            {
+                continue;
+            }
+
+            var aliasKey = parts[0].Trim();
+            var secretName = parts[1].Trim();
+            if (dict.TryGetValue(secretName, out var value))
+            {
+                dict[aliasKey] = value;
+            }
+            else
+            {
+                _logger.LogWarning("SECRET_MAPPINGS: secret {SecretName} not found for key {AliasKey}", secretName, aliasKey);
+            }
+        }
+
         return dict;
     }
 
@@ -93,7 +113,15 @@ public sealed class FunctionContext : IAsyncDisposable
             name,
             _httpClientFactory,
             Request,
-            _loggerFactory.CreateLogger<BatchManager>()));
+            _loggerFactory.CreateLogger<BatchManager>(),
+            onFlushed: (count, ct) => UpdateExecutionAsync(incrementCompletedObjects: count, ct: ct)));
+
+    /// <summary>
+    /// Adds an object to the named table's batch buffer.
+    /// Shorthand for <c>GetTable(table).AddObject(obj, updateStatus)</c>.
+    /// </summary>
+    public void SaveObject(string table, object obj, bool updateStatus = true)
+        => GetTable(table).AddObject(obj, updateStatus);
 
     /// <summary>
     /// Flushes all active table batch managers. The framework calls this automatically
@@ -163,6 +191,8 @@ public sealed class FunctionContext : IAsyncDisposable
     /// </summary>
     public async Task UpdateExecutionAsync(
         string? status = null,
+        int? totalObjects = null,
+        int? completedObjects = null,
         DateTimeOffset? completedAt = null,
         int incrementCompletedObjects = 0,
         CancellationToken ct = default)
@@ -177,6 +207,16 @@ public sealed class FunctionContext : IAsyncDisposable
         if (status is not null)
         {
             payload["status"] = status;
+        }
+
+        if (totalObjects is not null)
+        {
+            payload["totalObjects"] = totalObjects.Value;
+        }
+
+        if (completedObjects is not null)
+        {
+            payload["completedObjects"] = completedObjects.Value;
         }
 
         if (completedAt is not null)
@@ -215,68 +255,214 @@ public sealed class FunctionContext : IAsyncDisposable
         }
     }
 
-    // ── Checkpoint API ───────────────────────────────────────────────────────
+    // ── Connector State API ──────────────────────────────────────────────────
 
     /// <summary>
-    /// Reads the connector's pause/resume checkpoint state from Redis.
-    /// Returns null if no state has been saved.
+    /// Retrieves connector state from the connector-state service, keyed by scan ID.
+    /// Returns null if ScanId is not set or on error.
     /// </summary>
-    public Task<T?> GetConnectorStateAsync<T>(CancellationToken ct = default)
+    public async Task<Dictionary<string, string>?> GetConnectorStateAsync(CancellationToken ct = default)
     {
-        if (ScanExecutionId is null)
+        if (ScanId is null)
         {
-            return Task.FromResult<T?>(default);
+            _logger.LogWarning("GetConnectorStateAsync called but ScanId is null — skipping");
+            return null;
         }
 
-        return _redis.GetStateAsync<T>(ScanExecutionId, ct);
+        var serviceUrl = ServiceUrlHelper.Resolve("CONNECTOR_STATE_FUNCTION", "connector-state");
+        var url = $"{serviceUrl}?scanId={Uri.EscapeDataString(ScanId)}";
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient("connector-state");
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            foreach (var (k, v) in GetCallerHeaders())
+            {
+                request.Headers.TryAddWithoutValidation(k, v);
+            }
+
+            var response = await client.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("GetConnectorState returned {StatusCode}", (int)response.StatusCode);
+                return null;
+            }
+
+            var body = await response.Content.ReadAsStringAsync(ct);
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+
+            if (!root.TryGetProperty("success", out var successProp) || !successProp.GetBoolean())
+            {
+                var error = root.TryGetProperty("error", out var errProp) ? errProp.GetString() : "Unknown error";
+                _logger.LogWarning("GetConnectorState failed: {Error}", error);
+                return null;
+            }
+
+            if (root.TryGetProperty("data", out var dataProp))
+            {
+                return dataProp.Deserialize<Dictionary<string, string>>();
+            }
+
+            return new Dictionary<string, string>();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "GetConnectorState failed for scan {ScanId}", ScanId);
+            return null;
+        }
     }
 
     /// <summary>
-    /// Saves connector checkpoint state to Redis (TTL 24h).
+    /// Saves connector state to the connector-state service, keyed by scan ID.
     /// </summary>
-    public Task SetConnectorStateAsync<T>(T state, CancellationToken ct = default)
+    public async Task SetConnectorStateAsync(Dictionary<string, object?> data, CancellationToken ct = default)
     {
-        if (ScanExecutionId is null)
+        if (ScanId is null)
         {
-            return Task.CompletedTask;
+            _logger.LogWarning("SetConnectorStateAsync called but ScanId is null — skipping");
+            return;
         }
 
-        return _redis.SetStateAsync(ScanExecutionId, state, ct);
+        var serviceUrl = ServiceUrlHelper.Resolve("CONNECTOR_STATE_FUNCTION", "connector-state");
+        var payload = new { scanId = ScanId, data };
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient("connector-state");
+            using var request = new HttpRequestMessage(HttpMethod.Post, serviceUrl)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(payload), System.Text.Encoding.UTF8, "application/json"),
+            };
+            foreach (var (k, v) in GetCallerHeaders())
+            {
+                request.Headers.TryAddWithoutValidation(k, v);
+            }
+
+            var response = await client.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("SetConnectorState returned {StatusCode}", (int)response.StatusCode);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "SetConnectorState failed for scan {ScanId}", ScanId);
+        }
     }
 
     /// <summary>
-    /// Deletes the connector checkpoint state for the current execution.
+    /// Deletes connector state from the connector-state service.
+    /// If <paramref name="names"/> is null, deletes all state for the current scan.
     /// </summary>
-    public Task DeleteConnectorStateAsync(CancellationToken ct = default)
+    public async Task DeleteConnectorStateAsync(string[]? names = null, CancellationToken ct = default)
     {
-        if (ScanExecutionId is null)
+        if (ScanId is null)
         {
-            return Task.CompletedTask;
+            _logger.LogWarning("DeleteConnectorStateAsync called but ScanId is null — skipping");
+            return;
         }
 
-        return _redis.DeleteStateAsync(ScanExecutionId, ct);
+        var serviceUrl = ServiceUrlHelper.Resolve("CONNECTOR_STATE_FUNCTION", "connector-state");
+        var qs = $"?scanId={Uri.EscapeDataString(ScanId)}";
+        if (names is { Length: > 0 })
+        {
+            qs += string.Concat(names.Select(n => $"&name[]={Uri.EscapeDataString(n)}"));
+        }
+
+        var url = serviceUrl + qs;
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient("connector-state");
+            using var request = new HttpRequestMessage(HttpMethod.Delete, url);
+            foreach (var (k, v) in GetCallerHeaders())
+            {
+                request.Headers.TryAddWithoutValidation(k, v);
+            }
+
+            var response = await client.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("DeleteConnectorState returned {StatusCode}", (int)response.StatusCode);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "DeleteConnectorState failed for scan {ScanId}", ScanId);
+        }
     }
 
     /// <summary>
-    /// Reads checkpoint state saved by a prior execution (e.g., the paused run being resumed).
-    /// The prior execution ID is read from the <c>PRIOR_SCAN_EXECUTION_ID</c> environment variable.
-    /// <para>
-    /// <b>Limitation:</b> this reads from Redis only (<c>scan:state:{priorId}</c>).
-    /// If <c>REDIS_URL</c> is not configured, or the prior execution's state has expired (TTL 24h),
-    /// this method returns <c>null</c>.
-    /// Connectors that need durable resume state independent of Redis should call the
-    /// <c>connector-state</c> HTTP service directly via <c>IHttpClientFactory</c>.
-    /// </para>
+    /// Queries the app-data-query service for a prior scan execution by ID.
+    /// Returns null if not found or on error.
     /// </summary>
-    public Task<T?> GetPriorExecutionAsync<T>(CancellationToken ct = default)
+    public async Task<PriorExecution?> GetPriorExecutionAsync(string scanExecutionId, CancellationToken ct = default)
     {
-        var priorId = Environment.GetEnvironmentVariable("PRIOR_SCAN_EXECUTION_ID");
-        if (string.IsNullOrEmpty(priorId))
+        if (string.IsNullOrEmpty(scanExecutionId))
         {
-            return Task.FromResult<T?>(default);
+            return null;
         }
 
-        return _redis.GetStateAsync<T>(priorId, ct);
+        var serviceUrl = ServiceUrlHelper.Resolve("APP_DATA_QUERY_FUNCTION", "app-data-query");
+        var query = $"SELECT id, status, completed_objects FROM scan_executions WHERE id = '{scanExecutionId}' LIMIT 1";
+        var payload = new { query };
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient("app-data-query");
+            using var request = new HttpRequestMessage(HttpMethod.Post, serviceUrl)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(payload), System.Text.Encoding.UTF8, "application/json"),
+            };
+            foreach (var (k, v) in GetCallerHeaders())
+            {
+                request.Headers.TryAddWithoutValidation(k, v);
+            }
+
+            var response = await client.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("GetPriorExecution returned {StatusCode}", (int)response.StatusCode);
+                return null;
+            }
+
+            var body = await response.Content.ReadAsStringAsync(ct);
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+
+            if (!root.TryGetProperty("success", out var successProp) || !successProp.GetBoolean())
+            {
+                return null;
+            }
+
+            if (!root.TryGetProperty("data", out var dataProp) || dataProp.GetArrayLength() == 0)
+            {
+                return null;
+            }
+
+            var first = dataProp[0];
+            var id = first.TryGetProperty("id", out var idProp) ? idProp.GetString() ?? "" : "";
+            var status = first.TryGetProperty("status", out var statusProp) ? statusProp.GetString() ?? "" : "";
+            var coValue = first.TryGetProperty("completed_objects", out var coProp) ? coProp.GetInt32() : 0;
+
+            if (coValue <= 0)
+            {
+                _logger.LogInformation("No prior execution found for {ScanExecutionId}", scanExecutionId);
+                return null;
+            }
+
+            _logger.LogInformation(
+                "Retrieved prior execution {ScanExecutionId}: status={Status}, completedObjects={CompletedObjects}",
+                scanExecutionId, status, coValue);
+
+            return new PriorExecution(id, status, coValue);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error querying prior execution {ScanExecutionId}", scanExecutionId);
+            return null;
+        }
     }
 
     // ── Standard responses ───────────────────────────────────────────────────
@@ -286,6 +472,9 @@ public sealed class FunctionContext : IAsyncDisposable
 
     public static object AccessScanSuccessResponse()
         => new { statusCode = 200, body = new { } };
+
+    public static object GetObjectSuccessResponse(byte[] data)
+        => new { statusCode = 200, body = new { data = Convert.ToBase64String(data) } };
 
     public static object ErrorResponse(bool clientError, string message)
         => new { statusCode = clientError ? 400 : 500, body = new { error = message } };
@@ -301,3 +490,8 @@ public sealed class FunctionContext : IAsyncDisposable
         }
     }
 }
+
+/// <summary>
+/// Represents a prior scan execution returned from the app-data-query service.
+/// </summary>
+public sealed record PriorExecution(string Id, string Status, int CompletedObjects);

--- a/template/netwrix-csharp/ConnectorFramework/FunctionContext.cs
+++ b/template/netwrix-csharp/ConnectorFramework/FunctionContext.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text.Json;
+using Netwrix.Overlord.Sdk.Core.Storage;
 
 namespace Netwrix.ConnectorFramework;
 
@@ -16,6 +17,7 @@ public sealed class FunctionContext : IAsyncDisposable
     private readonly ILogger<FunctionContext> _logger;
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, BatchManager> _tables = new();
     private readonly ILoggerFactory _loggerFactory;
+    private readonly IStateStorage _stateStorage;
 
     public ConnectorRequestData Request { get; }
     public string? ScanId => Request.ScanId;
@@ -24,18 +26,23 @@ public sealed class FunctionContext : IAsyncDisposable
     /// <summary>Structured logger with automatic scan-context enrichment.</summary>
     public ILogger Log => _logger;
 
+    /// <summary>Typed key/value storage backed by the connector-state service.</summary>
+    public IStateStorage StateStorage => _stateStorage;
+
     public FunctionContext(
         ConnectorRequestData request,
         IConfiguration configuration,
         IHttpClientFactory httpClientFactory,
         ILogger<FunctionContext> logger,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        IStateStorage stateStorage)
     {
         Request = request;
         _configuration = configuration;
         _httpClientFactory = httpClientFactory;
         _logger = logger;
         _loggerFactory = loggerFactory;
+        _stateStorage = stateStorage;
     }
 
     // ── Secrets ───────────────────────────────────────────────────────────────
@@ -269,42 +276,18 @@ public sealed class FunctionContext : IAsyncDisposable
             return null;
         }
 
-        var serviceUrl = ServiceUrlHelper.Resolve("CONNECTOR_STATE_FUNCTION", "connector-state");
-        var url = $"{serviceUrl}?scanId={Uri.EscapeDataString(ScanId)}";
-
         try
         {
-            using var client = _httpClientFactory.CreateClient("connector-state");
-            using var request = new HttpRequestMessage(HttpMethod.Get, url);
-            foreach (var (k, v) in GetCallerHeaders())
+            var result = new Dictionary<string, string>();
+            await foreach (var key in _stateStorage.ListAllKeysAsync("", ct))
             {
-                request.Headers.TryAddWithoutValidation(k, v);
+                var r = await _stateStorage.TryGetAsync<string>(key, ct);
+                if (r.IsSuccess)
+                {
+                    result[key] = r.Value;
+                }
             }
-
-            var response = await client.SendAsync(request, ct);
-            if (!response.IsSuccessStatusCode)
-            {
-                _logger.LogWarning("GetConnectorState returned {StatusCode}", (int)response.StatusCode);
-                return null;
-            }
-
-            var body = await response.Content.ReadAsStringAsync(ct);
-            using var doc = JsonDocument.Parse(body);
-            var root = doc.RootElement;
-
-            if (!root.TryGetProperty("success", out var successProp) || !successProp.GetBoolean())
-            {
-                var error = root.TryGetProperty("error", out var errProp) ? errProp.GetString() : "Unknown error";
-                _logger.LogWarning("GetConnectorState failed: {Error}", error);
-                return null;
-            }
-
-            if (root.TryGetProperty("data", out var dataProp))
-            {
-                return dataProp.Deserialize<Dictionary<string, string>>();
-            }
-
-            return new Dictionary<string, string>();
+            return result;
         }
         catch (Exception ex)
         {
@@ -324,25 +307,14 @@ public sealed class FunctionContext : IAsyncDisposable
             return;
         }
 
-        var serviceUrl = ServiceUrlHelper.Resolve("CONNECTOR_STATE_FUNCTION", "connector-state");
-        var payload = new { scanId = ScanId, data };
-
         try
         {
-            using var client = _httpClientFactory.CreateClient("connector-state");
-            using var request = new HttpRequestMessage(HttpMethod.Post, serviceUrl)
+            foreach (var (key, value) in data)
             {
-                Content = new StringContent(JsonSerializer.Serialize(payload), System.Text.Encoding.UTF8, "application/json"),
-            };
-            foreach (var (k, v) in GetCallerHeaders())
-            {
-                request.Headers.TryAddWithoutValidation(k, v);
-            }
-
-            var response = await client.SendAsync(request, ct);
-            if (!response.IsSuccessStatusCode)
-            {
-                _logger.LogWarning("SetConnectorState returned {StatusCode}", (int)response.StatusCode);
+                if (value is not null)
+                {
+                    await _stateStorage.SetAsync<object>(key, value, ct);
+                }
             }
         }
         catch (Exception ex)
@@ -363,28 +335,18 @@ public sealed class FunctionContext : IAsyncDisposable
             return;
         }
 
-        var serviceUrl = ServiceUrlHelper.Resolve("CONNECTOR_STATE_FUNCTION", "connector-state");
-        var qs = $"?scanId={Uri.EscapeDataString(ScanId)}";
-        if (names is { Length: > 0 })
-        {
-            qs += string.Concat(names.Select(n => $"&name[]={Uri.EscapeDataString(n)}"));
-        }
-
-        var url = serviceUrl + qs;
-
         try
         {
-            using var client = _httpClientFactory.CreateClient("connector-state");
-            using var request = new HttpRequestMessage(HttpMethod.Delete, url);
-            foreach (var (k, v) in GetCallerHeaders())
+            if (names is null or { Length: 0 })
             {
-                request.Headers.TryAddWithoutValidation(k, v);
+                await _stateStorage.DeleteAllAsync("", ct);
             }
-
-            var response = await client.SendAsync(request, ct);
-            if (!response.IsSuccessStatusCode)
+            else
             {
-                _logger.LogWarning("DeleteConnectorState returned {StatusCode}", (int)response.StatusCode);
+                foreach (var name in names)
+                {
+                    await _stateStorage.DeleteAsync(name, ct);
+                }
             }
         }
         catch (Exception ex)

--- a/template/netwrix-csharp/ConnectorFramework/IConnectorHandler.cs
+++ b/template/netwrix-csharp/ConnectorFramework/IConnectorHandler.cs
@@ -9,8 +9,9 @@ public interface IConnectorHandler
     /// <summary>
     /// Optional: register connector-specific services into DI.
     /// Called before the host is built so the connector can add its own dependencies.
+    /// Use <paramref name="configuration"/> to bind typed options or call SDK extension methods.
     /// </summary>
-    void MapServices(IServiceCollection services) { }
+    void MapServices(IServiceCollection services, IConfiguration configuration) { }
 
     /// <summary>
     /// Optional (HTTP mode): map the connector's routes onto the ASP.NET Core application.

--- a/template/netwrix-csharp/ConnectorFramework/IScanProgress.cs
+++ b/template/netwrix-csharp/ConnectorFramework/IScanProgress.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics;
+
+namespace Netwrix.ConnectorFramework;
+
+/// <summary>
+/// Abstraction over the progress/telemetry side of <see cref="FunctionContext"/>.
+/// Implemented by <see cref="FunctionContext"/>; inject this interface into facades
+/// that need to report scan progress or emit OpenTelemetry spans.
+/// </summary>
+public interface IScanProgress
+{
+    ExecutionContext Execution { get; }
+    Activity? StartActivity(string name);
+    Task UpdateExecutionAsync(
+        string? status = null,
+        int? totalObjects = null,
+        int? completedObjects = null,
+        DateTimeOffset? completedAt = null,
+        int incrementCompletedObjects = 0,
+        CancellationToken ct = default);
+}

--- a/template/netwrix-csharp/ConnectorFramework/IScanWriter.cs
+++ b/template/netwrix-csharp/ConnectorFramework/IScanWriter.cs
@@ -1,0 +1,12 @@
+namespace Netwrix.ConnectorFramework;
+
+/// <summary>
+/// Abstraction over the write side of <see cref="FunctionContext"/>.
+/// Implemented by <see cref="FunctionContext"/>; inject this interface into facades
+/// that only need to buffer and flush scanned objects.
+/// </summary>
+public interface IScanWriter
+{
+    void SaveObject(string tableName, object obj, bool updateStatus = true);
+    Task FlushTablesAsync(CancellationToken ct = default);
+}

--- a/template/netwrix-csharp/ConnectorFramework/PriorExecution.cs
+++ b/template/netwrix-csharp/ConnectorFramework/PriorExecution.cs
@@ -1,0 +1,6 @@
+namespace Netwrix.ConnectorFramework;
+
+/// <summary>
+/// Represents a prior scan execution returned from the app-data-query service.
+/// </summary>
+public sealed record PriorExecution(string Id, string Status, int CompletedObjects);

--- a/template/netwrix-csharp/ConnectorFramework/Program.cs
+++ b/template/netwrix-csharp/ConnectorFramework/Program.cs
@@ -16,6 +16,9 @@ internal static class Program
 {
     private static readonly ActivitySource ActivitySource = new("Netwrix.ConnectorFramework");
 
+    private static string SanitizeForLog(string? value) =>
+        (value ?? string.Empty).Replace("\r", string.Empty).Replace("\n", string.Empty);
+
     public static async Task<int> Main(string[] args)
     {
         return IsJobMode()
@@ -63,7 +66,7 @@ internal static class Program
             using var activity = ActivitySource.StartActivity("process_request");
             requestLogger.LogInformation(
                 "Received request {Method} {Path}",
-                ctx.Request.Method, ctx.Request.Path.Value);
+                SanitizeForLog(ctx.Request.Method), SanitizeForLog(ctx.Request.Path.Value));
             try
             {
                 await next(ctx);
@@ -78,7 +81,7 @@ internal static class Program
                 activity?.RecordException(ex);
                 requestLogger.LogError(ex,
                     "Request failed {Method} {Path}",
-                    ctx.Request.Method, ctx.Request.Path.Value);
+                    SanitizeForLog(ctx.Request.Method), SanitizeForLog(ctx.Request.Path.Value));
                 throw;
             }
         });

--- a/template/netwrix-csharp/ConnectorFramework/Program.cs
+++ b/template/netwrix-csharp/ConnectorFramework/Program.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
@@ -12,14 +13,18 @@ namespace Netwrix.ConnectorFramework;
 
 internal static class Program
 {
+    private static readonly ActivitySource ActivitySource = new("Netwrix.ConnectorFramework");
+
     public static async Task<int> Main(string[] args)
     {
-        var executionMode = Environment.GetEnvironmentVariable("EXECUTION_MODE");
-
-        return executionMode == "job"
+        return IsJobMode()
             ? await RunJobModeAsync(args)
             : await RunHttpModeAsync(args);
     }
+
+    internal static bool IsJobMode() =>
+        Environment.GetEnvironmentVariable("EXECUTION_MODE") == "job" ||
+        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("REQUEST_DATA"));
 
     // ── HTTP mode ─────────────────────────────────────────────────────────────
 
@@ -41,6 +46,35 @@ internal static class Program
         builder.WebHost.UseUrls($"http://+:{port}");
 
         var app = builder.Build();
+
+        var requestLogger = app.Services
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger("Netwrix.ConnectorFramework.Program");
+
+        app.Use(async (ctx, next) =>
+        {
+            using var activity = ActivitySource.StartActivity("process_request");
+            requestLogger.LogInformation(
+                "Received request {Method} {Path}",
+                ctx.Request.Method, ctx.Request.Path.Value);
+            try
+            {
+                await next(ctx);
+                activity?.SetStatus(ActivityStatusCode.Ok);
+                requestLogger.LogInformation(
+                    "Request completed {StatusCode}",
+                    ctx.Response.StatusCode);
+            }
+            catch (Exception ex)
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                activity?.RecordException(ex);
+                requestLogger.LogError(ex,
+                    "Request failed {Method} {Path}",
+                    ctx.Request.Method, ctx.Request.Path.Value);
+                throw;
+            }
+        });
 
         // Enable buffering and eagerly read the body so the DI factory can access it synchronously.
         app.Use(async (ctx, next) =>
@@ -80,9 +114,12 @@ internal static class Program
 
         var logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Netwrix.ConnectorFramework.Program");
         int exitCode;
+        Activity? jobActivity = null;
         try
         {
             await using var scope = host.Services.CreateAsyncScope();
+
+            jobActivity = ActivitySource.StartActivity("job_execution");
 
             var requestData = BuildJobRequestData();
             // Make the job-mode request data available to scoped services
@@ -92,16 +129,34 @@ internal static class Program
             var handlerInstance = scope.ServiceProvider.GetRequiredService<IConnectorHandler>();
             var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
 
-            var result = await handlerInstance.HandleJobAsync(requestData, context, lifetime.ApplicationStopping);
+            logger.LogInformation(
+                "Starting job execution executionMode=job functionType={FunctionType} scanId={ScanId} scanExecutionId={ScanExecutionId}",
+                Environment.GetEnvironmentVariable("FUNCTION_TYPE"),
+                requestData.ScanId,
+                requestData.ScanExecutionId);
+
+            object result;
+            using (var handleActivity = ActivitySource.StartActivity("handle_request"))
+            {
+                result = await handlerInstance.HandleJobAsync(requestData, context, lifetime.ApplicationStopping);
+            }
             await context.FlushTablesAsync();
+
+            jobActivity?.SetStatus(ActivityStatusCode.Ok);
 
             Console.WriteLine(JsonSerializer.Serialize(result));
             exitCode = 0;
         }
         catch (Exception ex)
         {
+            jobActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            jobActivity?.RecordException(ex);
             logger.LogError(ex, "Job failed");
             exitCode = 1;
+        }
+        finally
+        {
+            jobActivity?.Dispose();
         }
 
         await host.StopAsync(); // flushes OTEL BatchSpanProcessor
@@ -143,6 +198,8 @@ internal static class Program
 
         // FunctionContext depends on ConnectorRequestData (scoped)
         services.AddScoped<FunctionContext>();
+        services.AddScoped<IScanWriter>(sp => sp.GetRequiredService<FunctionContext>());
+        services.AddScoped<IScanProgress>(sp => sp.GetRequiredService<FunctionContext>());
         services.AddScoped<IStateStorage, ConnectorStateStorage>();
 
         if (isHttpMode)
@@ -187,7 +244,7 @@ internal static class Program
 
     private static void RegisterOpenTelemetry(
         IServiceCollection services,
-        ILoggingBuilder? loggingBuilder,
+        ILoggingBuilder? _,
         bool isHttpMode)
     {
         if (Environment.GetEnvironmentVariable("OTEL_ENABLED")?.ToLowerInvariant() == "false")
@@ -307,6 +364,15 @@ internal static class Program
         return ms.ToArray();
     }
 
+    internal static string BuildRequestPath()
+    {
+        var functionType = Environment.GetEnvironmentVariable("FUNCTION_TYPE");
+        var derivedPath = functionType != null
+            ? $"/connector/{functionType.Replace("-", "_", StringComparison.Ordinal)}"
+            : "/connector/test_connection";
+        return Environment.GetEnvironmentVariable("REQUEST_PATH") ?? derivedPath;
+    }
+
     private static ConnectorRequestData BuildJobRequestData()
     {
         var requestDataJson = Environment.GetEnvironmentVariable("REQUEST_DATA") ?? "{}";
@@ -314,7 +380,7 @@ internal static class Program
 
         return new ConnectorRequestData(
             Method: "POST",
-            Path: Environment.GetEnvironmentVariable("REQUEST_PATH") ?? "/connector/test_connection",
+            Path: BuildRequestPath(),
             Headers: new Dictionary<string, string>(),
             Body: body,
             ScanId: Environment.GetEnvironmentVariable("SCAN_ID"),

--- a/template/netwrix-csharp/ConnectorFramework/Program.cs
+++ b/template/netwrix-csharp/ConnectorFramework/Program.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using Netwrix.Overlord.Sdk.Core.Storage;
+using OpenTelemetry.Exporter;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -40,9 +41,15 @@ internal static class Program
         builder.Services.AddSingleton(typeof(IConnectorHandler), handlerType);
         // Bootstrap instance (parameterless) used only to register connector services before container build.
         // The DI-resolved singleton is used for all request handling.
-        ((IConnectorHandler)Activator.CreateInstance(handlerType)!).MapServices(builder.Services);
+        ((IConnectorHandler)Activator.CreateInstance(handlerType)!).MapServices(builder.Services, builder.Configuration);
 
-        var port = int.Parse(Environment.GetEnvironmentVariable("PORT") ?? "5000", System.Globalization.CultureInfo.InvariantCulture);
+        var portStr = Environment.GetEnvironmentVariable("PORT") ?? "5000";
+        if (!int.TryParse(portStr, System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out var port))
+        {
+            throw new InvalidOperationException(
+                $"PORT environment variable '{portStr}' is not a valid port number.");
+        }
         builder.WebHost.UseUrls($"http://+:{port}");
 
         var app = builder.Build();
@@ -97,16 +104,16 @@ internal static class Program
     {
         var handlerType = DiscoverHandlerType();
 
-        var host = Host.CreateDefaultBuilder(args)
+        using var host = Host.CreateDefaultBuilder(args)
             .ConfigureLogging(ConfigureLogging)
-            .ConfigureServices((_, services) =>
+            .ConfigureServices((ctx, services) =>
             {
                 RegisterOpenTelemetry(services, null, isHttpMode: false);
                 RegisterFrameworkServices(services, isHttpMode: false);
 
                 services.AddSingleton(typeof(IConnectorHandler), handlerType);
                 // Bootstrap instance (parameterless) used only to register connector services before container build.
-                ((IConnectorHandler)Activator.CreateInstance(handlerType)!).MapServices(services);
+                ((IConnectorHandler)Activator.CreateInstance(handlerType)!).MapServices(services, ctx.Configuration);
             })
             .Build();
 
@@ -115,6 +122,8 @@ internal static class Program
         var logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Netwrix.ConnectorFramework.Program");
         int exitCode;
         Activity? jobActivity = null;
+        FunctionContext? context = null;
+        var isLongRunning = false;
         try
         {
             await using var scope = host.Services.CreateAsyncScope();
@@ -125,33 +134,55 @@ internal static class Program
             // Make the job-mode request data available to scoped services
             scope.ServiceProvider.GetRequiredService<RequestDataHolder>().Data = requestData;
 
-            var context = scope.ServiceProvider.GetRequiredService<FunctionContext>();
+            context = scope.ServiceProvider.GetRequiredService<FunctionContext>();
             var handlerInstance = scope.ServiceProvider.GetRequiredService<IConnectorHandler>();
             var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
 
-            logger.LogInformation(
-                "Starting job execution executionMode=job functionType={FunctionType} scanId={ScanId} scanExecutionId={ScanExecutionId}",
-                Environment.GetEnvironmentVariable("FUNCTION_TYPE"),
-                requestData.ScanId,
-                requestData.ScanExecutionId);
+            isLongRunning = requestData.Execution.IsLongRunning;
 
-            object result;
-            using (var handleActivity = ActivitySource.StartActivity("handle_request"))
+            using (logger.BeginScope(new Dictionary<string, object?>
             {
-                result = await handlerInstance.HandleJobAsync(requestData, context, lifetime.ApplicationStopping);
+                ["scan_id"] = requestData.Execution.ScanId,
+                ["scan_execution_id"] = requestData.Execution.ScanExecutionId,
+                ["function_type"] = requestData.Execution.FunctionType,
+                ["source_type"] = requestData.Execution.SourceType,
+                ["source_id"] = requestData.Execution.SourceId,
+            }))
+            {
+                logger.LogInformation(
+                    "Starting job execution executionMode=job functionType={FunctionType} scanId={ScanId} scanExecutionId={ScanExecutionId}",
+                    requestData.Execution.FunctionType,
+                    requestData.Execution.ScanId,
+                    requestData.Execution.ScanExecutionId);
+
+                if (isLongRunning)
+                {
+                    await context.UpdateExecutionAsync(status: ScanStatus.Running);
+                }
+
+                object result;
+                using (var handleActivity = ActivitySource.StartActivity("handle_request"))
+                {
+                    result = await handlerInstance.HandleJobAsync(requestData, context, lifetime.ApplicationStopping);
+                }
+                await context.FlushTablesAsync();
+
+                jobActivity?.SetStatus(ActivityStatusCode.Ok);
+
+                Console.WriteLine(JsonSerializer.Serialize(result));
+                exitCode = 0;
             }
-            await context.FlushTablesAsync();
-
-            jobActivity?.SetStatus(ActivityStatusCode.Ok);
-
-            Console.WriteLine(JsonSerializer.Serialize(result));
-            exitCode = 0;
         }
         catch (Exception ex)
         {
             jobActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             jobActivity?.RecordException(ex);
             logger.LogError(ex, "Job failed");
+            if (isLongRunning && context is not null)
+            {
+                await context.UpdateExecutionAsync(status: ScanStatus.Failed, completedAt: DateTimeOffset.UtcNow);
+            }
+
             exitCode = 1;
         }
         finally
@@ -159,7 +190,8 @@ internal static class Program
             jobActivity?.Dispose();
         }
 
-        await host.StopAsync(); // flushes OTEL BatchSpanProcessor
+        await host.StopAsync();
+        // host.Dispose() called here by using — triggers OpenTelemetryLoggerProvider.Dispose() → ForceFlush()
         return exitCode;
     }
 
@@ -235,10 +267,15 @@ internal static class Program
                     .Where(h => h.Value.Count > 0)
                     .ToDictionary(h => h.Key, h => h.Value.FirstOrDefault() ?? "", StringComparer.OrdinalIgnoreCase),
                 Body: body,
-                ScanId: http.Request.Headers["Scan-Id"].FirstOrDefault()
-                         ?? Environment.GetEnvironmentVariable("SCAN_ID"),
-                ScanExecutionId: http.Request.Headers["Scan-Execution-Id"].FirstOrDefault()
-                                  ?? Environment.GetEnvironmentVariable("SCAN_EXECUTION_ID"));
+                Execution: new ExecutionContext(
+                    ScanId: http.Request.Headers["Scan-Id"].FirstOrDefault()
+                                      ?? Environment.GetEnvironmentVariable("SCAN_ID"),
+                    ScanExecutionId: http.Request.Headers["Scan-Execution-Id"].FirstOrDefault()
+                                      ?? Environment.GetEnvironmentVariable("SCAN_EXECUTION_ID"),
+                    SourceId: Environment.GetEnvironmentVariable("SOURCE_ID"),
+                    SourceType: Environment.GetEnvironmentVariable("SOURCE_TYPE"),
+                    SourceVersion: Environment.GetEnvironmentVariable("SOURCE_VERSION"),
+                    FunctionType: Environment.GetEnvironmentVariable("FUNCTION_TYPE")));
         });
     }
 
@@ -256,6 +293,9 @@ internal static class Program
         var functionType = Environment.GetEnvironmentVariable("FUNCTION_TYPE") ?? "netwrix";
         var serviceName = $"{sourceType}-{functionType}";
         var environment = Environment.GetEnvironmentVariable("ENVIRONMENT") ?? "development";
+        // Default matches the Python template (index.py:118) and the in-cluster collector address.
+        // Connector authors running outside this cluster should set OTEL_EXPORTER_OTLP_ENDPOINT
+        // explicitly; leaving it unset will silently fail to export rather than error.
         var otelEndpoint = Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT")
                            ?? "http://otel-collector.access-analyzer.svc.cluster.local:4318";
 
@@ -279,7 +319,11 @@ internal static class Program
                     tracing.AddAspNetCoreInstrumentation();
                 }
 
-                tracing.AddOtlpExporter(o => o.Endpoint = new Uri($"{otelEndpoint}/v1/traces"));
+                tracing.AddOtlpExporter(o =>
+                {
+                    o.Endpoint = new Uri($"{otelEndpoint}/v1/traces");
+                    o.Protocol = OtlpExportProtocol.HttpProtobuf;
+                });
             })
             .WithMetrics(metrics =>
             {
@@ -291,18 +335,33 @@ internal static class Program
                     metrics.AddAspNetCoreInstrumentation();
                 }
 
-                metrics.AddOtlpExporter(o => o.Endpoint = new Uri($"{otelEndpoint}/v1/metrics"));
+                metrics.AddOtlpExporter(o =>
+                {
+                    o.Endpoint = new Uri($"{otelEndpoint}/v1/metrics");
+                    o.Protocol = OtlpExportProtocol.HttpProtobuf;
+                });
             })
-            .WithLogging(logging =>
-            {
-                logging.SetResourceBuilder(resourceBuilder)
-                    .AddOtlpExporter(o => o.Endpoint = new Uri($"{otelEndpoint}/v1/logs"));
-            });
+            .WithLogging(
+                logging =>
+                {
+                    logging.SetResourceBuilder(resourceBuilder)
+                        .AddOtlpExporter(o =>
+                        {
+                            o.Endpoint = new Uri($"{otelEndpoint}/v1/logs");
+                            o.Protocol = OtlpExportProtocol.HttpProtobuf;
+                        });
+                },
+                options =>
+                {
+                    options.IncludeFormattedMessage = true;  // populate Body in ClickHouse
+                    options.IncludeScopes = true;            // capture BeginScope() values as attributes
+                    options.ParseStateValues = true;         // capture {ScanId} etc. as structured attributes
+                });
     }
 
     // ── Handler discovery ─────────────────────────────────────────────────────
 
-    private static Type DiscoverHandlerType()
+    internal static Type DiscoverHandlerType()
     {
         // The function assembly sits in the same directory as ConnectorFramework.dll.
         // It is the single assembly (other than ConnectorFramework itself) that references this assembly.
@@ -315,7 +374,12 @@ internal static class Program
             .Select(f =>
             {
                 try { return Assembly.LoadFrom(f); }
-                catch { return null; }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine(
+                        $"[ConnectorFramework] Warning: failed to load assembly '{f}': {ex.Message}");
+                    return null;
+                }
             })
             .Where(a => a is not null)
             .Cast<Assembly>()
@@ -324,7 +388,16 @@ internal static class Program
             .ToList();
 
         var handlerTypes = candidateAssemblies
-            .SelectMany(a => { try { return a.GetTypes(); } catch { return []; } })
+            .SelectMany(a =>
+            {
+                try { return a.GetTypes(); }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine(
+                        $"[ConnectorFramework] Warning: failed to enumerate types in '{a.FullName}': {ex.Message}");
+                    return [];
+                }
+            })
             .Where(t => !t.IsAbstract && !t.IsInterface && typeof(IConnectorHandler).IsAssignableFrom(t))
             .ToList();
 
@@ -383,7 +456,12 @@ internal static class Program
             Path: BuildRequestPath(),
             Headers: new Dictionary<string, string>(),
             Body: body,
-            ScanId: Environment.GetEnvironmentVariable("SCAN_ID"),
-            ScanExecutionId: Environment.GetEnvironmentVariable("SCAN_EXECUTION_ID"));
+            Execution: new ExecutionContext(
+                ScanId: Environment.GetEnvironmentVariable("SCAN_ID"),
+                ScanExecutionId: Environment.GetEnvironmentVariable("SCAN_EXECUTION_ID"),
+                SourceId: Environment.GetEnvironmentVariable("SOURCE_ID"),
+                SourceType: Environment.GetEnvironmentVariable("SOURCE_TYPE"),
+                SourceVersion: Environment.GetEnvironmentVariable("SOURCE_VERSION"),
+                FunctionType: Environment.GetEnvironmentVariable("FUNCTION_TYPE")));
     }
 }

--- a/template/netwrix-csharp/ConnectorFramework/Program.cs
+++ b/template/netwrix-csharp/ConnectorFramework/Program.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
+using Netwrix.Overlord.Sdk.Core.Storage;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -142,6 +143,7 @@ internal static class Program
 
         // FunctionContext depends on ConnectorRequestData (scoped)
         services.AddScoped<FunctionContext>();
+        services.AddScoped<IStateStorage, ConnectorStateStorage>();
 
         if (isHttpMode)
         {
@@ -154,13 +156,17 @@ internal static class Program
             // CreateBackgroundScope() or RunJobModeAsync() respectively.
             var holder = sp.GetRequiredService<RequestDataHolder>();
             if (holder.IsSet)
+            {
                 return holder.Data;
+            }
 
             var http = sp.GetService<IHttpContextAccessor>()?.HttpContext;
             if (http is null)
+            {
                 throw new InvalidOperationException(
                     "ConnectorRequestData cannot be resolved outside of an HTTP request context. " +
                     "Use IServiceScopeFactory.CreateBackgroundScope(requestData) for background scopes.");
+            }
 
             // Body was pre-read by the middleware into HttpContext.Items to avoid sync I/O in the factory.
             var body = http.Items["_body"] as byte[];

--- a/template/netwrix-csharp/ConnectorFramework/ScanStatus.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ScanStatus.cs
@@ -1,0 +1,13 @@
+namespace Netwrix.ConnectorFramework;
+
+public static class ScanStatus
+{
+    public const string Running = "running";
+    public const string Failed = "failed";
+    public const string Completed = "completed";
+    public const string Stopped = "stopped";
+    public const string Paused = "paused";
+    public const string Pausing = "pausing";
+    public const string Resuming = "resuming";
+    public const string Stopping = "stopping";
+}

--- a/template/netwrix-csharp/ConnectorFramework/ServiceUrlHelper.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ServiceUrlHelper.cs
@@ -16,7 +16,7 @@ internal static class ServiceUrlHelper
     public static string Resolve(string envVarOverride, string defaultServiceName, int port = 80, bool useAsync = false)
     {
         var overrideUrl = Environment.GetEnvironmentVariable(envVarOverride);
-        if (!string.IsNullOrEmpty(overrideUrl))
+        if (!string.IsNullOrEmpty(overrideUrl) && Uri.IsWellFormedUriString(overrideUrl, UriKind.Absolute))
         {
             return overrideUrl;
         }

--- a/template/netwrix-csharp/ConnectorFramework/StateManager.cs
+++ b/template/netwrix-csharp/ConnectorFramework/StateManager.cs
@@ -8,23 +8,24 @@ public sealed class StateManager : IAsyncDisposable
     private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> ValidTransitions =
         new Dictionary<string, IReadOnlyList<string>>
         {
-            ["running"] = ["stopping", "pausing", "completed", "failed"],
-            ["stopping"] = ["stopped", "failed"],
-            ["stopped"] = [],
-            ["pausing"] = ["paused", "failed"],
-            ["paused"] = ["resuming", "failed", "stopped"],
-            ["resuming"] = ["running", "failed"],
-            ["completed"] = [],
-            ["failed"] = [],
+            [ScanStatus.Running] = [ScanStatus.Stopping, ScanStatus.Pausing, ScanStatus.Completed, ScanStatus.Failed],
+            [ScanStatus.Stopping] = [ScanStatus.Stopped, ScanStatus.Failed],
+            [ScanStatus.Stopped] = [],
+            [ScanStatus.Pausing] = [ScanStatus.Paused, ScanStatus.Failed],
+            [ScanStatus.Paused] = [ScanStatus.Resuming, ScanStatus.Failed, ScanStatus.Stopped],
+            [ScanStatus.Resuming] = [ScanStatus.Running, ScanStatus.Failed],
+            [ScanStatus.Completed] = [],
+            [ScanStatus.Failed] = [],
         };
 
     private readonly RedisSignalHandler _redis;
     private readonly ScanShutdownService _shutdown;
+    private readonly IScanProgress _progress;
     private readonly ILogger<StateManager> _logger;
     private readonly SemaphoreSlim _semaphore = new(1, 1);
     private readonly List<Func<string, string, Task>> _callbacks = [];
 
-    private volatile string _currentState = "running";
+    private volatile string _currentState = ScanStatus.Running;
     private string? _requestedState;
     private DateTimeOffset _lastSignalCheck = DateTimeOffset.MinValue;
 
@@ -41,12 +42,14 @@ public sealed class StateManager : IAsyncDisposable
     public StateManager(
         RedisSignalHandler redis,
         ScanShutdownService shutdown,
+        IScanProgress progress,
         ILogger<StateManager> logger,
         SupportedStates? supportedStates = null,
         int signalCheckIntervalSeconds = 5)
     {
         _redis = redis;
         _shutdown = shutdown;
+        _progress = progress;
         _logger = logger;
         SupportedStates = supportedStates ?? new SupportedStates();
         SignalCheckIntervalSeconds = signalCheckIntervalSeconds;
@@ -208,7 +211,7 @@ public sealed class StateManager : IAsyncDisposable
     /// </summary>
     public async Task<bool> ShutdownAsync(
         string executionId,
-        string finalStatus = "stopped",
+        string finalStatus = ScanStatus.Stopped,
         CancellationToken ct = default)
     {
         try
@@ -219,11 +222,16 @@ public sealed class StateManager : IAsyncDisposable
                 return false;
             }
 
+            await _progress.UpdateExecutionAsync(
+                status: finalStatus,
+                completedAt: finalStatus != ScanStatus.Paused ? DateTimeOffset.UtcNow : null,
+                ct: ct);
+
             await _redis.UpdateStatusAsync(
                 executionId,
                 finalStatus,
                 "Execution stopped",
-                partialData: finalStatus == "stopped",
+                partialData: finalStatus == ScanStatus.Stopped,
                 ct: ct);
 
             await _redis.CleanupStreamsAsync(executionId, ct);

--- a/template/netwrix-csharp/README.md
+++ b/template/netwrix-csharp/README.md
@@ -1,0 +1,275 @@
+# Netwrix C# Connector Template
+
+## Overview
+
+This template provides the scaffolding for a Netwrix DSPM connector written in C#. The repository is split into two parts:
+
+- **`ConnectorFramework/`** — Shared framework code that is copied unchanged into every connector. Contains the per-request context, batch management, state storage, signal handling, and SDK facade adapters. Do not modify this directory in your connector project.
+- **`function/`** — Per-connector implementation. Implement your connector operations in `Handler.cs`. Add connector-specific NuGet packages to `function/Function.csproj` only.
+
+The connector runs in two modes:
+
+- **HTTP mode** (default) — an ASP.NET Core minimal-API server. Operations like `test_connection` return directly; long-running scans return `202 Accepted` and execute in the background via `IServiceScopeFactory`.
+- **Job mode** (`EXECUTION_MODE=job`) — a single invocation that runs, writes results, then exits. Used by container-based job schedulers.
+
+---
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────┐
+│  SDK Contract (Netwrix.Overlord.Sdk.Cloud)           │
+│  ICorePlatformFacade · ICrawlTaskManagementPlatformFacade │
+└───────────────────────┬──────────────────────────────┘
+                        │ implemented by
+┌───────────────────────▼──────────────────────────────┐
+│  Facade Adapters (ConnectorFramework/)               │
+│  AACorePlatformFacade          → depends on IScanWriter   │
+│  AACrawlTaskCorePlatformFacade → depends on IScanWriter   │
+│                                  + IScanProgress      │
+└───────────────────────┬──────────────────────────────┘
+                        │ implemented by
+┌───────────────────────▼──────────────────────────────┐
+│  Framework Infrastructure (ConnectorFramework/)      │
+│  FunctionContext (scoped) — implements IScanWriter    │
+│                              and IScanProgress        │
+│    • BatchManager — HTTP batching to data-ingestion   │
+│    • IStateStorage / ConnectorStateStorage            │
+│    • UpdateExecutionAsync — progress reporting        │
+│    • GetPriorExecutionAsync — prior execution lookup  │
+│    • StartActivity — OpenTelemetry spans              │
+│    • Secrets — /var/secrets lazy loader               │
+│    • Log — structured logger with scan-context scope  │
+│  StateManager (scoped) — pause/stop FSM              │
+│    • SupportedStates — declares stop/pause capability │
+│    • OnStateChange — transition callbacks             │
+│  RedisSignalHandler — Redis stream signal polling     │
+│  ScanShutdownService (singleton) — app lifetime       │
+│  ExecutionContext — immutable scan metadata           │
+│  ScanStatus — terminal/intermediate status constants  │
+└──────────────────────────────────────────────────────┘
+```
+
+### Key types
+
+| Type | Lifetime | Purpose |
+|---|---|---|
+| `FunctionContext` | Scoped | Per-request context. Provides `IScanWriter`, `IScanProgress`, secrets, state, telemetry. |
+| `IScanWriter` | Scoped (alias of `FunctionContext`) | Write objects and flush batches. Inject into facades that buffer scan output. |
+| `IScanProgress` | Scoped (alias of `FunctionContext`) | Report progress and emit OTel spans. Inject into facades that track execution progress. |
+| `ExecutionContext` | Immutable record | Scan metadata (`ScanId`, `ScanExecutionId`, `SourceId`, `SourceType`, `FunctionType`, `SourceVersion`). Exposed as `ctx.Execution`. |
+| `ScanStatus` | Static constants | String constants for all scan states (`Running`, `Completed`, `Failed`, `Stopped`, `Paused`, …). Use instead of raw strings. |
+| `PriorExecution` | Immutable record | Result of `GetPriorExecutionAsync` — holds `Id`, `Status`, `CompletedObjects` from a previous scan execution. |
+| `AACorePlatformFacade` | Scoped | SDK adapter — translates `ICorePlatformFacade` calls into `IScanWriter` operations. |
+| `AACrawlTaskCorePlatformFacade` | Scoped | Crawl-task orchestration — delegates `ICorePlatformFacade` methods to `AACorePlatformFacade` and uses `IScanProgress` for progress updates. |
+| `StateManager` | Scoped | Pause/stop state machine backed by `RedisSignalHandler`. |
+| `SupportedStates` | Record | Declares which control signals this connector handles (`Stop`, `Pause`, `Resume`). Defaults to stop-only. |
+| `BatchManager` | Scoped (owned by `FunctionContext`) | Buffers objects and flushes them to the data-ingestion HTTP endpoint in configurable batch sizes. |
+| `RedisSignalHandler` | Scoped | Reads control signals (pause, stop) and writes status to Redis streams. |
+| `ScanShutdownService` | Singleton | Provides an `ApplicationStopping` token shared across all scopes. |
+
+---
+
+## Execution lifecycle
+
+`ShutdownAsync` updates both Redis and the `app-update-execution` HTTP service. Always call it with a terminal status at the end of every scan path — including catch blocks.
+
+Use `ScanStatus` constants instead of raw strings:
+
+| Constant | Value | When to use |
+|---|---|---|
+| `ScanStatus.Completed` | `"completed"` | Scan finished successfully. |
+| `ScanStatus.Stopped` | `"stopped"` | A STOP signal was received (`ShouldStopAsync` returned `true`). |
+| `ScanStatus.Paused` | `"paused"` | A PAUSE signal was received (`ShouldPauseAsync` returned `true`). |
+| `ScanStatus.Failed` | `"failed"` | An unhandled exception occurred. |
+
+**Job mode:** the framework auto-sets `"running"` before calling `HandleJobAsync` (for long-running function types) and `"failed"` if an unhandled exception escapes the handler — but handlers should still call `ShutdownAsync` explicitly for proper Redis cleanup. The framework's `"failed"` call is a safety net only.
+
+---
+
+## Two approaches to writing a connector
+
+### Approach A — SDK-driven (crawl task connectors)
+
+> Use when the Netwrix Overlord SDK drives the scan via `ICorePlatformFacade` / `ICrawlTaskManagementPlatformFacade`.
+
+The SDK calls your facade's `UploadSiTRecords`, `UploadSiTSchemaRecords`, and `UploadActivityRecords` methods. The facade handles batching automatically.
+
+**Register in `MapServices()`:**
+```csharp
+services.AddScoped<AACorePlatformFacade>();
+services.AddScoped<AACrawlTaskCorePlatformFacade>();
+services.AddScoped<ICrawlTaskManagementPlatformFacade>(
+    sp => sp.GetRequiredService<AACrawlTaskCorePlatformFacade>());
+services.AddScoped<ICrawlTaskCorePlatformFacade>(
+    sp => sp.GetRequiredService<AACrawlTaskCorePlatformFacade>());
+services.AddScoped<ICorePlatformFacade>(
+    sp => sp.GetRequiredService<AACrawlTaskCorePlatformFacade>());
+```
+
+**Typical scan lifecycle:**
+```csharp
+facade.Initialize(source, configs);
+
+// SDK drives UploadSiTRecords / UploadSiTSchemaRecords calls internally
+
+await facade.FinalizeScan();
+```
+
+Example connector using this approach: `sharepoint-online-ccf`
+
+---
+
+### Approach B — Handler-driven (simple/custom connectors)
+
+> Use when the handler owns the scan loop and writes objects directly without SDK orchestration.
+
+Inject `FunctionContext` (or `IScanWriter`) directly into your endpoint handler.
+
+**Important:** In background `Task.Run` blocks you must use `scopeFactory.CreateBackgroundScope(requestData)` instead of `CreateAsyncScope()` — this pre-seeds the scope with the captured request data so `FunctionContext` resolves correctly outside the HTTP request lifetime.
+
+**Typical scan loop:**
+```csharp
+app.MapPost("/connector/access_scan", async (
+    FunctionContext ctx,
+    IServiceScopeFactory scopeFactory,
+    CancellationToken kestrelCt) =>
+{
+    var requestData = ctx.Request; // capture before Task.Run
+    _ = Task.Run(async () =>
+    {
+        await using var scope = scopeFactory.CreateBackgroundScope(requestData);
+        var ctx = scope.ServiceProvider.GetRequiredService<FunctionContext>();
+        var stateManager = scope.ServiceProvider.GetRequiredService<StateManager>();
+        var executionId = ctx.Execution.ScanExecutionId!;
+
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(
+            kestrelCt, stateManager.Token);
+        var ct = linked.Token;
+
+        try
+        {
+            foreach (var item in GetItems())
+            {
+                if (await stateManager.ShouldStopAsync(executionId, ct))
+                {
+                    await stateManager.ShutdownAsync(executionId, ScanStatus.Stopped, ct);
+                    return;
+                }
+                if (await stateManager.ShouldPauseAsync(executionId, ct))
+                {
+                    await ctx.SetConnectorStateAsync(
+                        new Dictionary<string, object?> { ["lastProcessed"] = item.Id }, ct);
+                    await stateManager.ShutdownAsync(executionId, ScanStatus.Paused, ct);
+                    return;
+                }
+
+                ctx.SaveObject("objects", item);
+            }
+
+            await ctx.FlushTablesAsync(ct);
+            await stateManager.ShutdownAsync(executionId, ScanStatus.Completed, ct);
+        }
+        catch (Exception)
+        {
+            await stateManager.ShutdownAsync(executionId, ScanStatus.Failed, ct);
+            throw;
+        }
+    });
+    return Results.Accepted();
+});
+```
+
+Example connector using this approach: `fake-fs`
+
+---
+
+## Key services reference
+
+| Service | Lifetime | Registration |
+|---|---|---|
+| `FunctionContext` | Scoped | Framework (`Program.cs`) |
+| `IScanWriter` | Scoped | Framework — alias of `FunctionContext` |
+| `IScanProgress` | Scoped | Framework — alias of `FunctionContext` |
+| `IStateStorage` | Scoped | Framework — `ConnectorStateStorage` |
+| `StateManager` | Scoped | Framework |
+| `RedisSignalHandler` | Scoped | Framework |
+| `ScanShutdownService` | Singleton | Framework |
+| `AACorePlatformFacade` | Scoped | Connector `Handler.MapServices()` |
+| `AACrawlTaskCorePlatformFacade` | Scoped | Connector `Handler.MapServices()` |
+| `ICorePlatformFacade` | Scoped | Connector `Handler.MapServices()` |
+| `ICrawlTaskManagementPlatformFacade` | Scoped | Connector `Handler.MapServices()` |
+
+---
+
+## `FunctionContext` API reference
+
+| Member | Description |
+|---|---|
+| `ctx.Execution` | `ExecutionContext` — immutable scan metadata (IDs, source type, function type). |
+| `ctx.Log` | Structured `ILogger` automatically scoped with `scan_id`, `scan_execution_id`, `function_type`, and `source_type`. |
+| `ctx.Secrets` | Lazy-loaded dictionary of secrets from `/var/secrets/` with `SECRET_MAPPINGS` aliases applied. |
+| `ctx.StateStorage` | `IStateStorage` backed by the connector-state service. Prefer the typed methods below for common operations. |
+| `ctx.SaveObject(table, obj)` | Buffers an object into the named table's `BatchManager`. |
+| `ctx.GetTable(table)` | Returns (or lazily creates) a `BatchManager` for the given table — use when you need direct batch control. |
+| `ctx.FlushTablesAsync(ct)` | Flushes all active table buffers to the data-ingestion service. |
+| `ctx.UpdateExecutionAsync(...)` | Reports scan progress to the upstream connector-api. |
+| `ctx.GetConnectorStateAsync(ct)` | Retrieves all connector state keys for the current scan ID. |
+| `ctx.SetConnectorStateAsync(dict, ct)` | Writes a `Dictionary<string, object?>` to the connector-state service. |
+| `ctx.DeleteConnectorStateAsync(names, ct)` | Deletes specific keys (or all state if `names` is null). |
+| `ctx.GetPriorExecutionAsync(scanExecutionId, ct)` | Queries `app-data-query` for a previous execution by ID. Returns a `PriorExecution` record or null if not found. |
+| `ctx.StartActivity(name)` | Starts an OpenTelemetry span. Always use with `using`. |
+| `ctx.GetCallerHeaders()` | Returns W3C trace-context and scan-context headers for outbound HTTP calls. |
+| `FunctionContext.TestConnectionSuccessResponse()` | Standard `test_connection` success payload. |
+| `FunctionContext.ErrorResponse(clientError, message)` | Standard error payload (400 or 500). |
+
+---
+
+## `StateManager` API reference
+
+`StateManager` defaults to supporting only the STOP signal. To enable pause and/or resume, register a custom `SupportedStates` before the framework registers `StateManager`, or pass it via the constructor in tests.
+
+```csharp
+// In MapServices() — enable pause support
+services.AddScoped(_ => new SupportedStates(Stop: true, Pause: true, Resume: true));
+```
+
+| Member | Description |
+|---|---|
+| `stateManager.Token` | `CancellationToken` cancelled when a STOP signal arrives or `ShutdownAsync` is called. |
+| `stateManager.CurrentState` | Current state string (volatile read — safe from any thread). |
+| `stateManager.ShouldStopAsync(executionId, ct)` | Polls Redis (throttled to `SignalCheckIntervalSeconds`) and returns `true` if a STOP was received. Returns `false` if `SupportedStates.Stop` is false. |
+| `stateManager.ShouldPauseAsync(executionId, ct)` | Like `ShouldStopAsync` but for PAUSE. Returns `false` if `SupportedStates.Pause` is false. |
+| `stateManager.ShutdownAsync(executionId, finalStatus, ct)` | Transitions state, calls `UpdateExecutionAsync`, publishes status to Redis, and cancels the token. |
+| `stateManager.SetStateAsync(newState, ct)` | Manual state transition — returns `false` if invalid from the current state. |
+| `stateManager.OnStateChange(callback)` | Registers an async callback invoked after every successful state transition. |
+
+---
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `EXECUTION_MODE` | `""` (HTTP) | Set to `job` to run in job mode. |
+| `PORT` | `5000` | HTTP listen port (HTTP mode only). |
+| `SCAN_ID` | — | Scan identifier injected into `ConnectorRequestData`. |
+| `SCAN_EXECUTION_ID` | — | Scan execution identifier for progress reporting. |
+| `SOURCE_ID` | — | Source instance identifier. |
+| `SOURCE_TYPE` | `internal` | Source type tag. Used in OTel service name and structured logs. |
+| `SOURCE_VERSION` | — | Source version tag. |
+| `REQUEST_DATA` | `{}` | JSON request body for job mode. |
+| `REQUEST_PATH` | derived | Request path for job mode. Derived from `FUNCTION_TYPE` as `/connector/{function_type}` if not explicitly set. |
+| `REDIS_URL` | — | Redis connection string. Required for pause/stop signals. |
+| `SECRET_MAPPINGS` | — | Comma-separated `appKey:secretFile` alias pairs (e.g. `dbPass:my-db-secret`). |
+| `FUNCTION_TYPE` | `netwrix` | OpenTelemetry service name suffix; also added to outbound `Function-Type` header and used to derive `REQUEST_PATH` in job mode. |
+| `ENVIRONMENT` | `development` | Deployment environment tag in OTel resource attributes. |
+| `OTEL_ENABLED` | `true` | Set to `false` to disable all OpenTelemetry export. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://otel-collector...` | OTLP collector endpoint. |
+| `APP_UPDATE_EXECUTION_FUNCTION` | — | Override URL for the `app-update-execution` service. |
+| `APP_DATA_QUERY_FUNCTION` | — | Override URL for the `app-data-query` service. |
+| `CONNECTOR_STATE_FUNCTION` | — | Override URL for the `connector-state` service. |
+| `LOG_LEVEL` | `Information` | Minimum log level (`DEBUG`, `WARNING`, `ERROR`, `Information`). |
+| `RUN_LOCAL` | — | Set to `true` to resolve service URLs as `http://{serviceName}:8080`. |
+| `USE_OPENFAAS_GATEWAY` | — | Set to `true` to route service calls through the OpenFaaS gateway. |
+| `OPENFAAS_GATEWAY` | `http://gateway.openfaas:8080` | OpenFaaS gateway URL (used when `USE_OPENFAAS_GATEWAY=true`). |
+| `COMMON_FUNCTIONS_NAMESPACE` | `access-analyzer` | Kubernetes namespace for in-cluster service DNS resolution. |

--- a/template/netwrix-csharp/function/AACorePlatformFacade.cs
+++ b/template/netwrix-csharp/function/AACorePlatformFacade.cs
@@ -3,7 +3,6 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Netwrix.ConnectorFramework;
 using Netwrix.Overlord.Sdk.Cloud;
-using Netwrix.Overlord.Sdk.Cloud.Models;
 using Netwrix.Overlord.Sdk.Cloud.TaskScheduler.Models;
 using Netwrix.Overlord.Sdk.Core.Activity.Models;
 using Netwrix.Overlord.Sdk.Core.State.Models;
@@ -12,85 +11,85 @@ namespace Netwrix.Connector;
 
 public class AACorePlatformFacade : ICorePlatformFacade
 {
-	protected readonly ILogger _logger;
-	protected readonly IHttpClientFactory _httpClientFactory;
-	protected readonly FunctionContext FunctionContext;
+    protected readonly ILogger _logger;
+    protected readonly IHttpClientFactory _httpClientFactory;
+    protected readonly FunctionContext FunctionContext;
 
-	public AACorePlatformFacade(
-		ILogger<AACorePlatformFacade> logger,
-		IHttpClientFactory httpClientFactory,
-		FunctionContext functionContext)
-	{
-		_logger = logger;
-		_httpClientFactory = httpClientFactory;
-		FunctionContext = functionContext;
-	}
+    public AACorePlatformFacade(
+        ILogger<AACorePlatformFacade> logger,
+        IHttpClientFactory httpClientFactory,
+        FunctionContext functionContext)
+    {
+        _logger = logger;
+        _httpClientFactory = httpClientFactory;
+        FunctionContext = functionContext;
+    }
 
-	/// <summary>
-	/// Data is transmitted as plain JSON; no decryption is performed in Access Analyzer connectors.
-	/// </summary>
-	public Task<TData> DecryptData<TData>(byte[] encryptedKey, byte[] encryptedPayload)
-	{
-		var payloadString = Encoding.UTF8.GetString(encryptedPayload);
-		var payloadObject = JsonSerializer.Deserialize<TData>(payloadString);
-		return Task.FromResult(payloadObject
-			?? throw new InvalidOperationException("Unable to deserialize data payload."));
-	}
+    /// <summary>
+    /// Data is transmitted as plain JSON; no decryption is performed in Access Analyzer connectors.
+    /// </summary>
+    public Task<TData> DecryptData<TData>(byte[] encryptedKey, byte[] encryptedPayload)
+    {
+        var payloadString = Encoding.UTF8.GetString(encryptedPayload);
+        var payloadObject = JsonSerializer.Deserialize<TData>(payloadString);
+        return Task.FromResult(payloadObject
+            ?? throw new InvalidOperationException("Unable to deserialize data payload."));
+    }
 
-	/// <summary>
-	/// Data is transmitted as plain JSON; no decryption is performed in Access Analyzer connectors.
-	/// </summary>
-	public Task<TData> DecryptTenancyData<TData>(byte[] encryptedKey, byte[] encryptedPayload)
-	{
-		var payloadObject = JsonSerializer.Deserialize<TData>(Encoding.UTF8.GetString(encryptedPayload));
-		return Task.FromResult(payloadObject
-			?? throw new InvalidOperationException("Unable to deserialize tenancy data payload."));
-	}
+    /// <summary>
+    /// Data is transmitted as plain JSON; no decryption is performed in Access Analyzer connectors.
+    /// </summary>
+    public Task<TData> DecryptTenancyData<TData>(byte[] encryptedKey, byte[] encryptedPayload)
+    {
+        var payloadObject = JsonSerializer.Deserialize<TData>(Encoding.UTF8.GetString(encryptedPayload));
+        return Task.FromResult(payloadObject
+            ?? throw new InvalidOperationException("Unable to deserialize tenancy data payload."));
+    }
 
-	public Task<TMessage> DecryptServiceBusMessage<TMessage>(string message)
-	{
-		throw new NotSupportedException(
-			"Service bus message decryption is not supported in Access Analyzer connectors.");
-	}
+    public Task<TMessage> DecryptServiceBusMessage<TMessage>(string message)
+    {
+        throw new NotSupportedException(
+            "Service bus message decryption is not supported in Access Analyzer connectors.");
+    }
 
-	public Task UploadActivityRecords(List<ActivityRecord> activityRecords)
-	{
-		// Activity upload not implemented for Access Analyzer connector.
-		// TODO T2: Implement or document as intentionally unsupported with NotSupportedException.
-		return Task.CompletedTask;
-	}
+    public Task UploadActivityRecords(List<ActivityRecord> activityRecords)
+    {
+        // Activity upload not implemented for Access Analyzer connector.
+        // TODO T2: Implement or document as intentionally unsupported with NotSupportedException.
+        return Task.CompletedTask;
+    }
 
-	/// <summary>
-	/// Uploads SiT (State in Time) records to the core platform.
-	///
-	/// NOTE: The object-type label map (Guid to type name) is connector-specific and must be
-	/// added by the connector developer in their own project — do not add it to the template.
-	/// See TODO T10.
-	/// </summary>
-	public async Task UploadSiTRecords(
-		CrawlContext context,
-		List<SitObjectImportModel> objectModels,
-		List<SitMappingImportModel> mappingModels,
-		List<SitImportActionModel> actionModels,
-		bool isFinal,
-		int chunkId = 1)
-	{
-		using var activity = FunctionContext.StartActivity("upload-sit-records");
+    /// <summary>
+    /// Uploads SiT (State in Time) records to the core platform.
+    ///
+    /// NOTE: The object-type label map (Guid to type name) is connector-specific and must be
+    /// added by the connector developer in their own project — do not add it to the template.
+    /// See TODO T10.
+    /// </summary>
+    public async Task UploadSiTRecords(
+        CrawlContext context,
+        List<SitObjectImportModel> objectModels,
+        List<SitMappingImportModel> mappingModels,
+        List<SitImportActionModel> actionModels,
+        bool isFinal,
+        int chunkId = 1)
+    {
+        using var activity = FunctionContext.StartActivity("upload-sit-records");
 
-		foreach (var obj in objectModels)
-		{
-			_logger.LogInformation("Object {Type} {Count} properties",
-				obj.Type, obj.Properties?.Count ?? 0);
-			FunctionContext.GetTable("objects").AddObject(obj);
-		}
+        foreach (var obj in objectModels)
+        {
+            _logger.LogInformation("Object {Type} {Count} properties",
+                obj.Type, obj.Properties?.Count ?? 0);
+            FunctionContext.GetTable("objects").AddObject(obj);
+        }
 
-		// TODO T1: Implement mapping model upload — FunctionContext.GetTable("mapping").AddObject(m)
-		// TODO T1: Implement action model upload  — FunctionContext.GetTable("action").AddObject(a)
+        // TODO T1: Implement mapping model upload — FunctionContext.GetTable("mapping").AddObject(m)
+        // TODO T1: Implement action model upload  — FunctionContext.GetTable("action").AddObject(a)
 
-		if (isFinal)
-		{
-			_logger.LogInformation("Final upload — flushing all pending batches");
-			await FunctionContext.FlushTablesAsync();
-		}
-	}
+        if (isFinal)
+        {
+            _logger.LogInformation("Final upload — flushing all pending batches");
+            await FunctionContext.FlushTablesAsync();
+        }
+    }
 }

--- a/template/netwrix-csharp/function/AACrawlTaskCorePlatformFacade.cs
+++ b/template/netwrix-csharp/function/AACrawlTaskCorePlatformFacade.cs
@@ -2,7 +2,6 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Netwrix.ConnectorFramework;
-using Netwrix.Overlord.Sdk.Cloud;
 using Netwrix.Overlord.Sdk.Cloud.TaskScheduler;
 using Netwrix.Overlord.Sdk.Cloud.TaskScheduler.Models;
 using Netwrix.Overlord.Sdk.Cloud.TaskScheduler.Models.Api;
@@ -11,128 +10,134 @@ namespace Netwrix.Connector;
 
 public class AACrawlTaskCorePlatformFacade : AACorePlatformFacade, ICrawlTaskManagementPlatformFacade
 {
-	private const int MaxUpdateIntervalMinutes = 5;
+    private const int MaxUpdateIntervalMinutes = 5;
 
-	private readonly ConcurrentQueue<ApiChildCrawlTask> _crawlTaskQueue = new();
-	private readonly ConcurrentDictionary<Guid, int> _processedItems = new();
-	private readonly ConcurrentDictionary<Guid, int> _processedErrors = new();
-	private int _reportedItemsCount;
-	private long _lastUpdateTimestamp = Stopwatch.GetTimestamp();
+    private readonly ConcurrentQueue<ApiChildCrawlTask> _crawlTaskQueue = new();
+    private readonly ConcurrentDictionary<Guid, int> _processedItems = new();
+    private readonly ConcurrentDictionary<Guid, int> _processedErrors = new();
+    private int _reportedItemsCount;
+    private long _lastUpdateTimestamp = Stopwatch.GetTimestamp();
 
-	private CrawlTaskConfiguration.SourcePayload? _sourcePayload;
-	private List<CrawlTaskConfiguration.ConnectorConfigPayload>? _connectorConfigs;
+    private CrawlTaskConfiguration.SourcePayload? _sourcePayload;
+    private List<CrawlTaskConfiguration.ConnectorConfigPayload>? _connectorConfigs;
 
-	public AACrawlTaskCorePlatformFacade(
-		ILogger<AACrawlTaskCorePlatformFacade> logger,
-		IHttpClientFactory httpClientFactory,
-		FunctionContext functionContext)
-		: base(logger, httpClientFactory, functionContext)
-	{
-	}
+    public AACrawlTaskCorePlatformFacade(
+        ILogger<AACrawlTaskCorePlatformFacade> logger,
+        IHttpClientFactory httpClientFactory,
+        FunctionContext functionContext)
+        : base(logger, httpClientFactory, functionContext)
+    {
+    }
 
-	/// <summary>
-	/// Exposes the queue of child crawl tasks enqueued during <see cref="FinaliseTask"/>.
-	/// Drain this queue after the scan loop completes to schedule sub-tasks.
-	/// </summary>
-	public ConcurrentQueue<ApiChildCrawlTask> CrawlTaskQueue => _crawlTaskQueue;
+    /// <summary>
+    /// Exposes the queue of child crawl tasks enqueued during <see cref="FinaliseTask"/>.
+    /// Drain this queue after the scan loop completes to schedule sub-tasks.
+    /// </summary>
+    public ConcurrentQueue<ApiChildCrawlTask> CrawlTaskQueue => _crawlTaskQueue;
 
-	/// <summary>
-	/// Stores the request payloads deserialized from the connector request body.
-	/// Must be called before <see cref="StartTask"/>.
-	/// </summary>
-	public void Initialize(
-		CrawlTaskConfiguration.SourcePayload source,
-		List<CrawlTaskConfiguration.ConnectorConfigPayload> configs)
-	{
-		_sourcePayload = source;
-		_connectorConfigs = configs;
-	}
+    /// <summary>
+    /// Stores the request payloads deserialized from the connector request body.
+    /// Must be called before <see cref="StartTask"/>.
+    /// </summary>
+    public void Initialize(
+        CrawlTaskConfiguration.SourcePayload source,
+        List<CrawlTaskConfiguration.ConnectorConfigPayload> configs)
+    {
+        _sourcePayload = source;
+        _connectorConfigs = configs;
+    }
 
-	public Task<CrawlTaskConfiguration> StartTask(Guid crawlTaskReference, DateTimeOffset startDate)
-	{
-		if (_sourcePayload is null || _connectorConfigs is null)
-			throw new InvalidOperationException("Initialize() must be called before StartTask.");
+    public Task<CrawlTaskConfiguration> StartTask(Guid crawlTaskReference, DateTimeOffset startDate)
+    {
+        if (_sourcePayload is null || _connectorConfigs is null)
+        {
+            throw new InvalidOperationException("Initialize() must be called before StartTask.");
+        }
 
-		return Task.FromResult(new CrawlTaskConfiguration
-		{
-			TenancyReference = Guid.Empty,
-			FeatureFlags = [],
-			Source = _sourcePayload,
-			ConnectorConfigs = _connectorConfigs
-		});
-	}
+        return Task.FromResult(new CrawlTaskConfiguration
+        {
+            TenancyReference = Guid.Empty,
+            FeatureFlags = [],
+            Source = _sourcePayload,
+            ConnectorConfigs = _connectorConfigs
+        });
+    }
 
-	public async Task EnsureRegularTaskProgressUpdate(Guid taskReference, CrawlResponse taskProgress)
-	{
-		_processedErrors.AddOrUpdate(
-			taskReference,
-			taskProgress.ConnectorResults?.Sum(x => x.ItemErrorCount) ?? 0,
-			(_, _) => taskProgress.ConnectorResults?.Sum(x => x.ItemErrorCount) ?? 0);
+    public async Task EnsureRegularTaskProgressUpdate(Guid taskReference, CrawlResponse taskProgress)
+    {
+        _processedErrors.AddOrUpdate(
+            taskReference,
+            taskProgress.ConnectorResults?.Sum(x => x.ItemErrorCount) ?? 0,
+            (_, _) => taskProgress.ConnectorResults?.Sum(x => x.ItemErrorCount) ?? 0);
 
-		_processedItems.AddOrUpdate(
-			taskReference,
-			taskProgress.ProcessedItemCount,
-			(_, _) => taskProgress.ProcessedItemCount);
+        _processedItems.AddOrUpdate(
+            taskReference,
+            taskProgress.ProcessedItemCount,
+            (_, _) => taskProgress.ProcessedItemCount);
 
-		// Throttle: only call the platform at most once per MaxUpdateIntervalMinutes
-		if (Stopwatch.GetElapsedTime(_lastUpdateTimestamp).TotalMinutes < MaxUpdateIntervalMinutes)
-			return;
+        // Throttle: only call the platform at most once per MaxUpdateIntervalMinutes
+        if (Stopwatch.GetElapsedTime(_lastUpdateTimestamp).TotalMinutes < MaxUpdateIntervalMinutes)
+        {
+            return;
+        }
 
-		try
-		{
-			using var activity = FunctionContext.StartActivity("update-execution-progress");
-			var totalItems = _processedItems.Values.Sum();
-			var delta = totalItems - _reportedItemsCount;
-			await FunctionContext.UpdateExecutionAsync(
-				status: "running",
-				incrementCompletedObjects: delta);
-			_reportedItemsCount = totalItems;
-			_lastUpdateTimestamp = Stopwatch.GetTimestamp();
-		}
-		catch (Exception ex)
-		{
-			_logger.LogWarning(ex, "Unable to perform regular task update for task {TaskReference}", taskReference);
-		}
-	}
+        try
+        {
+            using var activity = FunctionContext.StartActivity("update-execution-progress");
+            var totalItems = _processedItems.Values.Sum();
+            var delta = totalItems - _reportedItemsCount;
+            await FunctionContext.UpdateExecutionAsync(
+                status: "running",
+                incrementCompletedObjects: delta);
+            _reportedItemsCount = totalItems;
+            _lastUpdateTimestamp = Stopwatch.GetTimestamp();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Unable to perform regular task update for task {TaskReference}", taskReference);
+        }
+    }
 
-	public Task FinaliseTask(APICrawlTaskProgress taskProgress)
-	{
-		if (taskProgress.ChildTasks is null)
-			return Task.CompletedTask;
+    public Task FinaliseTask(APICrawlTaskProgress taskProgress)
+    {
+        if (taskProgress.ChildTasks is null)
+        {
+            return Task.CompletedTask;
+        }
 
-		_processedErrors.AddOrUpdate(
-			taskProgress.CrawlTaskReference,
-			taskProgress.CrawlTaskResults?.Sum(x => x.ItemErrorCount) ?? 0,
-			(_, _) => taskProgress.CrawlTaskResults?.Sum(x => x.ItemErrorCount) ?? 0);
+        _processedErrors.AddOrUpdate(
+            taskProgress.CrawlTaskReference,
+            taskProgress.CrawlTaskResults?.Sum(x => x.ItemErrorCount) ?? 0,
+            (_, _) => taskProgress.CrawlTaskResults?.Sum(x => x.ItemErrorCount) ?? 0);
 
-		_processedItems.AddOrUpdate(
-			taskProgress.CrawlTaskReference,
-			taskProgress.ProcessedItemCount,
-			(_, _) => taskProgress.ProcessedItemCount);
+        _processedItems.AddOrUpdate(
+            taskProgress.CrawlTaskReference,
+            taskProgress.ProcessedItemCount,
+            (_, _) => taskProgress.ProcessedItemCount);
 
-		foreach (var childTask in taskProgress.ChildTasks)
-		{
-			_crawlTaskQueue.Enqueue(childTask);
-		}
+        foreach (var childTask in taskProgress.ChildTasks)
+        {
+            _crawlTaskQueue.Enqueue(childTask);
+        }
 
-		return Task.CompletedTask;
-	}
+        return Task.CompletedTask;
+    }
 
-	public async Task FinalizeScan()
-	{
-		try
-		{
-			using var activity = FunctionContext.StartActivity("finalize-scan");
-			var totalItems = _processedItems.Values.Sum();
-			var delta = totalItems - _reportedItemsCount;
-			await FunctionContext.UpdateExecutionAsync(
-				status: "completed",
-				incrementCompletedObjects: delta);
-		}
-		catch (Exception ex)
-		{
-			_logger.LogWarning(ex, "Unable to finalize scan status {ScanExecutionId}",
-				FunctionContext.ScanExecutionId);
-		}
-	}
+    public async Task FinalizeScan()
+    {
+        try
+        {
+            using var activity = FunctionContext.StartActivity("finalize-scan");
+            var totalItems = _processedItems.Values.Sum();
+            var delta = totalItems - _reportedItemsCount;
+            await FunctionContext.UpdateExecutionAsync(
+                status: "completed",
+                incrementCompletedObjects: delta);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Unable to finalize scan status {ScanExecutionId}",
+                FunctionContext.ScanExecutionId);
+        }
+    }
 }

--- a/template/netwrix-csharp/function/Handler.cs
+++ b/template/netwrix-csharp/function/Handler.cs
@@ -32,8 +32,9 @@ public class Handler : IConnectorHandler
     ///
     /// TODO: add connector-specific services after this block (e.g. SharePoint graph client, options).
     /// </summary>
-    public void MapServices(IServiceCollection services)
+    public void MapServices(IServiceCollection services, IConfiguration configuration)
     {
+        services.AddScoped<AACorePlatformFacade>();
         services.AddScoped<AACrawlTaskCorePlatformFacade>();
         services.AddScoped<ICrawlTaskManagementPlatformFacade>(
             sp => sp.GetRequiredService<AACrawlTaskCorePlatformFacade>());
@@ -103,8 +104,7 @@ public class Handler : IConnectorHandler
     //     StateManager stateManager,
     //     CancellationToken ct)
     // {
-    //     var executionId = ctx.ScanExecutionId ?? throw new InvalidOperationException("ScanExecutionId is required");
-    //     await stateManager.SetStateAsync("running", ct);
+    //     var executionId = ctx.Execution.ScanExecutionId ?? throw new InvalidOperationException("ScanExecutionId is required");
     //
     //     try
     //     {
@@ -113,7 +113,11 @@ public class Handler : IConnectorHandler
     //
     //         foreach (var item in GetItems())
     //         {
-    //             if (await stateManager.ShouldStopAsync(executionId, ct)) break;
+    //             if (await stateManager.ShouldStopAsync(executionId, ct))
+    //             {
+    //                 await stateManager.ShutdownAsync(executionId, "stopped", ct);
+    //                 return;
+    //             }
     //             if (await stateManager.ShouldPauseAsync(executionId, ct))
     //             {
     //                 await ctx.SetConnectorStateAsync(new { lastProcessed = item.Id }, ct);
@@ -122,7 +126,6 @@ public class Handler : IConnectorHandler
     //             }
     //
     //             table.AddObject(item);
-    //             await ctx.UpdateExecutionAsync(incrementCompletedObjects: 1, ct: ct);
     //         }
     //
     //         await ctx.FlushTablesAsync(ct);

--- a/template/netwrix-internal-csharp/function/Function.csproj
+++ b/template/netwrix-internal-csharp/function/Function.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- Aligns the C# connector template with the Python reference implementation, introducing a consistent architecture across both templates
- Refactors platform facades (`AACorePlatformFacade`, `AACrawlTaskCorePlatformFacade`) into the `ConnectorFramework` project and updates them to depend on abstraction interfaces
- Adds `ConnectorStateStorage` backed by the connector-state HTTP service, with `IStateStorage` interface for testability
- Introduces foundational types and interfaces (`IScanProgress`, `IScanWriter`, `ScanStatus`, `PriorExecution`, `ExecutionContext`) to mirror Python abstractions
- Enriches `FunctionContext` with state storage, structured logging, and root span management (framework-owned)
- Adds comprehensive test coverage for new components (`FunctionContextTests`, `ConnectorStateStorageTests`, `AACorePlatformFacadeTests`, etc.)
- Disables activity record upload until landing tables are in place; removes scan execution properties from state upload

## Test plan

- [x] All new test classes pass: `FunctionContextTests`, `ConnectorStateStorageTests`, `AACorePlatformFacadeTests`, `AACrawlTaskCorePlatformFacadeTests`, `ProgramTests`, `ServiceUrlHelperTests`, `StateManagerTests`, `BatchManagerTests`
- [x] Verify `ConnectorStateStorage` correctly reads/writes state via the connector-state HTTP service
- [x] Verify `FunctionContext` correctly initializes and exposes state storage, logging, and spans
- [x] Confirm platform facades resolve correctly from DI and behave as expected in integration scenarios
- [x] Smoke test the template by running a connector locally end-to-end

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>