### PR TITLE
feat(templates): add state management and connector state to netwrix-internal-python

### DIFF
--- a/template/netwrix-internal-python/Dockerfile
+++ b/template/netwrix-internal-python/Dockerfile
@@ -62,7 +62,10 @@ RUN --mount=from=ghcr.io/astral-sh/uv,source=/uv,target=/bin/uv \
 
 # Copy template-provided function files (state_manager, redis_signal_handler, etc)
 COPY --chown=app:app ./template/netwrix-internal-python/function/ .
+COPY --chown=app:app ./template/netwrix-internal-python/redis_signal_handler.py    .
+COPY --chown=app:app ./template/netwrix-internal-python/state_manager.py           .
 
+# Copy function-specific code (handler, requirements, etc) - this overrides template defaults if present
 COPY --chown=app:app ${FUNCTION_DIR}/ .
 
 FROM build AS ship

--- a/template/netwrix-internal-python/index.py
+++ b/template/netwrix-internal-python/index.py
@@ -28,13 +28,13 @@ dictConfig(
             }
         },
         "handlers": {
-            "wsgi": {
+            "console": {
                 "class": "logging.StreamHandler",
-                "stream": "ext://flask.logging.wsgi_errors_stream",
+                "stream": "ext://sys.stderr",
                 "formatter": "default",
             }
         },
-        "root": {"level": os.getenv("LOG_LEVEL", "INFO").upper(), "handlers": ["wsgi"]},
+        "root": {"level": os.getenv("LOG_LEVEL", "INFO").upper(), "handlers": ["console"]},
     }
 )
 

--- a/template/netwrix-internal-python/index.py
+++ b/template/netwrix-internal-python/index.py
@@ -14,6 +14,7 @@ from collections.abc import Callable
 from logging.config import dictConfig
 from typing import Final
 
+import requests
 from flask import Flask, jsonify, request
 from opentelemetry import metrics, trace
 from opentelemetry.trace.status import StatusCode
@@ -39,8 +40,23 @@ dictConfig(
 )
 
 SERVICE_NAME: Final = os.getenv("SERVICE_NAME", __name__)
+COMMON_FUNCTIONS_NAMESPACE: Final = os.getenv("COMMON_FUNCTIONS_NAMESPACE", "access-analyzer")
 TRACE_ISOLATION_ENABLED: Final = os.getenv("TRACE_ISOLATION_ENABLED", "false").lower() == "true"
 app = Flask(SERVICE_NAME)
+
+
+def get_service_url(service_name: str, port: int = 80) -> str:
+    """
+    Get the URL for a common function service.
+
+    Uses Kubernetes FQDN format:
+    http://<service-name>.<namespace>.svc.cluster.local:<port>
+
+    Args:
+        service_name: Name of the service to call
+        port: Port number (default: 80)
+    """
+    return f"http://{service_name}.{COMMON_FUNCTIONS_NAMESPACE}.svc.cluster.local:{port}"
 
 
 def setup_opentelemetry(app: object | None = None) -> Callable[[], None]:
@@ -174,6 +190,157 @@ class Context:
         self.log = ContextLogger(self)
         self.caller_attributes = caller_attributes
         self.execution_mode = "http"
+        self.scan_id: str | None = None
+        self.scan_execution_id: str | None = None
+
+    def access_scan_success_response(self):
+        return {"statusCode": 200, "body": {}}
+
+    def get_caller_headers(self) -> dict[str, str]:
+        """
+        Build headers dict with caller context information to pass to common functions.
+        Only includes headers that have non-None values.
+        """
+        return {"Scan-Id": self.scan_id or "", "Scan-Execution-Id": self.scan_execution_id or ""}
+
+    def get_connector_state(self) -> dict:
+        """
+        Retrieve connector state from the connector-state function for the current scan_id.
+
+        Returns:
+            dict: Dictionary containing the connector state key-value pairs
+
+        Raises:
+            ValueError: If scan_id is not set
+            Exception: If the request fails
+        """
+        if not self.scan_id:
+            raise ValueError("scan_id must be set to retrieve connector state")
+
+        try:
+            headers = {"Content-Type": "application/json", **self.get_caller_headers()}
+
+            service_name = os.getenv("CONNECTOR_STATE_FUNCTION", "connector-state")
+            url = get_service_url(service_name)
+
+            response = requests.get(
+                url,
+                params={"scanId": self.scan_id},
+                headers=headers,
+                timeout=30,
+            )
+
+            if response.status_code == 200:
+                result = response.json()
+                if result.get("success"):
+                    self.log.info("Retrieved connector state successfully", key_count=len(result.get("data", {})))
+                    return result.get("data", {})
+                error_msg = f"Failed to retrieve connector state: {result.get('error', 'Unknown error')}"
+                raise Exception(error_msg)
+
+            error_msg = f"Status {response.status_code}: {response.text}"
+            raise Exception(error_msg)
+        except Exception:
+            raise
+
+    def set_connector_state(self, data: dict) -> tuple[bool, str | None]:
+        """
+        Save connector state to the connector-state function for the current scan_id.
+
+        Args:
+            data: Dictionary of key-value pairs to save
+
+        Returns:
+            tuple: (success: bool, error_message: str | None)
+
+        Raises:
+            ValueError: If scan_id is not set or data is not a dictionary
+        """
+        if not self.scan_id:
+            raise ValueError("scan_id must be set to save connector state")
+
+        if not isinstance(data, dict):
+            raise ValueError("data must be a dictionary")
+
+        try:
+            payload = {"scanId": self.scan_id, "data": data}
+
+            headers = {"Content-Type": "application/json", **self.get_caller_headers()}
+
+            service_name = os.getenv("CONNECTOR_STATE_FUNCTION", "connector-state")
+            url = get_service_url(service_name)
+
+            response = requests.post(
+                url,
+                json=payload,
+                headers=headers,
+                timeout=30,
+            )
+
+            if response.status_code == 200:
+                result = response.json()
+                if result.get("success"):
+                    self.log.info("Saved connector state successfully", key_count=len(data))
+                    return True, None
+                error_msg = f"Failed to save connector state: {result.get('error', 'Unknown error')}"
+                return False, error_msg
+
+            error_msg = f"Status {response.status_code}: {response.text}"
+            return False, error_msg
+        except Exception as e:
+            error_msg = f"Error saving connector state: {str(e)}"
+            return False, error_msg
+
+    def delete_connector_state(self, names: list[str] | None = None) -> tuple[bool, str | None]:
+        """
+        Delete connector state from the connector-state function for the current scan_id.
+
+        Args:
+            names: Optional list of item names to delete. If None, deletes all data for the scan_id.
+
+        Returns:
+            tuple: (success: bool, error_message: str | None)
+
+        Raises:
+            ValueError: If scan_id is not set
+        """
+        if not self.scan_id:
+            raise ValueError("scan_id must be set to delete connector state")
+
+        try:
+            params: dict[str, str | list[str]] = {"scanId": self.scan_id}
+            if names:
+                params["name"] = names
+
+            headers = {"Content-Type": "application/json", **self.get_caller_headers()}
+
+            service_name = os.getenv("CONNECTOR_STATE_FUNCTION", "connector-state")
+            url = get_service_url(service_name)
+
+            response = requests.delete(
+                url,
+                params=params,
+                headers=headers,
+                timeout=30,
+            )
+
+            if response.status_code == 200:
+                result = response.json()
+                if result.get("success"):
+                    log_attrs = {}
+                    if names:
+                        log_attrs["deleted_names"] = names
+                        log_attrs["deleted_count"] = len(names)
+                    self.log.info("Deleted connector state successfully", **log_attrs)
+                    return True, None
+                error_msg = f"Failed to delete connector state: {result.get('error', 'Unknown error')}"
+                return False, error_msg
+
+            error_msg = f"Status {response.status_code}: {response.text}"
+            return False, error_msg
+        except Exception as e:
+            error_msg = f"Error deleting connector state: {str(e)}"
+            return False, error_msg
 
     def create_thread(self, target, *args, **kwargs):
         """
@@ -210,6 +377,69 @@ class Context:
 
         # Create thread with wrapped target
         return threading.Thread(*args, target=wrapped_target, **kwargs)
+
+    def get_prior_execution(self, scan_execution_id: str) -> dict | None:
+        """
+        Query Postgres scan_executions table for prior execution with same scan_execution_id.
+
+        Used to detect if a scan is resuming from a paused state.
+
+        Args:
+            scan_execution_id: The execution ID to query
+
+        Returns:
+            dict with 'status' field if found, None if not found or on error
+        """
+        try:
+            # Query Postgres for scan execution status via app-data-query function
+            query = (
+                f"SELECT id, status, completed_objects FROM scan_executions WHERE id = '{scan_execution_id}' LIMIT 1"
+            )
+            payload = {"query": query}
+
+            # Build headers with caller context information
+            headers = {"Content-Type": "application/json", **self.get_caller_headers()}
+
+            # Get service URL for app-data-query using standard routing
+            service_name = os.getenv("APP_DATA_QUERY_FUNCTION", "app-data-query")
+            url = get_service_url(service_name)
+
+            response = requests.post(
+                url,
+                json=payload,
+                headers=headers,
+                timeout=30,
+            )
+
+            if response.status_code == 200:
+                result = response.json()
+                if result.get("success"):
+                    data = result.get("data", [])
+                    if data and len(data) > 0:
+                        execution_data = data[0]
+                        completed_objects = execution_data.get("completed_objects")
+                        if completed_objects > 0:
+                            self.log.info(
+                                "Retrieved prior execution",
+                                scan_execution_id=scan_execution_id,
+                                completed_objects=completed_objects,
+                                status=execution_data.get("status"),
+                            )
+                            return execution_data
+                    self.log.info("No prior execution found", scan_execution_id=scan_execution_id)
+                    return None
+                self.log.info(
+                    "Query failed", scan_execution_id=scan_execution_id, error=result.get("error", "Unknown error")
+                )
+                return None
+            self.log.info(
+                "Failed to query prior execution", status_code=response.status_code, response=response.text[:200]
+            )
+            return None
+
+        except Exception as e:
+            self.log.warning("Error querying prior execution", scan_execution_id=scan_execution_id, error=str(e))
+            return None
 
 
 class ContextLogger:
@@ -330,6 +560,8 @@ def call_handler(path):
                 "scan_execution_id": event.headers.get("Scan-Execution-Id"),
             }
             context = Context(caller_attributes)
+            context.scan_id = caller_attributes.get("scan_id")
+            context.scan_execution_id = caller_attributes.get("scan_execution_id")
 
             context.log.info(
                 "Received request",
@@ -366,6 +598,7 @@ def call_handler(path):
             "scan_execution_id": event.headers.get("Scan-Execution-Id"),
         }
         context = Context(caller_attributes)
+        context.scan_execution_id = caller_attributes.get("scan_execution_id")
 
         context.log.info(
             "Received request",
@@ -420,13 +653,26 @@ def get_execution_mode() -> str:
 def run_as_job():
     """Execute handler once as a Kubernetes job."""
     # Create a new span when trace isolation is enabled
+    # Parse scan execution ID from REQUEST_DATA environment variable
+    request_data_str = os.getenv("REQUEST_DATA", "{}")
+    try:
+        request_data = json.loads(request_data_str)
+    except json.JSONDecodeError:
+        request_data = {}
+
+    scan_id = request_data.get("scanId") or os.getenv("SCAN_ID")
+    scan_execution_id = request_data.get("scanExecutionId") or os.getenv("SCAN_EXECUTION_ID")
+
     if TRACE_ISOLATION_ENABLED:
         with tracer.start_as_current_span("job_execution") as span:
-            ctx = Context({})
+            ctx = Context({"scan_id": scan_id, "scan_execution_id": scan_execution_id})
+            ctx.scan_id = scan_id
+            ctx.scan_execution_id = scan_execution_id
 
             ctx.log.info(
                 "Starting job execution",
                 execution_mode="job",
+                scan_execution_id=scan_execution_id,
             )
 
             ctx.execution_mode = "job"
@@ -473,11 +719,14 @@ def run_as_job():
             print(json.dumps(result))
             sys.exit(0 if result["success"] else 1)
     else:
-        ctx = Context({})
+        ctx = Context({"scan_id": scan_id, "scan_execution_id": scan_execution_id})
+        ctx.scan_id = scan_id
+        ctx.scan_execution_id = scan_execution_id
 
         ctx.log.info(
             "Starting job execution",
             execution_mode="job",
+            scan_execution_id=scan_execution_id,
         )
 
         ctx.execution_mode = "job"

--- a/template/netwrix-internal-python/index.py
+++ b/template/netwrix-internal-python/index.py
@@ -217,31 +217,28 @@ class Context:
         if not self.scan_id:
             raise ValueError("scan_id must be set to retrieve connector state")
 
-        try:
-            headers = {"Content-Type": "application/json", **self.get_caller_headers()}
+        headers = {"Content-Type": "application/json", **self.get_caller_headers()}
 
-            service_name = os.getenv("CONNECTOR_STATE_FUNCTION", "connector-state")
-            url = get_service_url(service_name)
+        service_name = os.getenv("CONNECTOR_STATE_FUNCTION", "connector-state")
+        url = get_service_url(service_name)
 
-            response = requests.get(
-                url,
-                params={"scanId": self.scan_id},
-                headers=headers,
-                timeout=30,
-            )
+        response = requests.get(
+            url,
+            params={"scanId": self.scan_id},
+            headers=headers,
+            timeout=30,
+        )
 
-            if response.status_code == 200:
-                result = response.json()
-                if result.get("success"):
-                    self.log.info("Retrieved connector state successfully", key_count=len(result.get("data", {})))
-                    return result.get("data", {})
-                error_msg = f"Failed to retrieve connector state: {result.get('error', 'Unknown error')}"
-                raise Exception(error_msg)
-
-            error_msg = f"Status {response.status_code}: {response.text}"
+        if response.status_code == 200:
+            result = response.json()
+            if result.get("success"):
+                self.log.info("Retrieved connector state successfully", key_count=len(result.get("data", {})))
+                return result.get("data", {})
+            error_msg = f"Failed to retrieve connector state: {result.get('error', 'Unknown error')}"
             raise Exception(error_msg)
-        except Exception:
-            raise
+
+        error_msg = f"Status {response.status_code}: {response.text}"
+        raise Exception(error_msg)
 
     def set_connector_state(self, data: dict) -> tuple[bool, str | None]:
         """
@@ -392,8 +389,9 @@ class Context:
         """
         try:
             # Query Postgres for scan execution status via app-data-query function
+            safe_scan_execution_id = scan_execution_id.replace("'", "''")
             query = (
-                f"SELECT id, status, completed_objects FROM scan_executions WHERE id = '{scan_execution_id}' LIMIT 1"
+                f"SELECT id, status, completed_objects FROM scan_executions WHERE id = '{safe_scan_execution_id}' LIMIT 1"
             )
             payload = {"query": query}
 

--- a/template/netwrix-internal-python/pyproject.toml
+++ b/template/netwrix-internal-python/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "opentelemetry-instrumentation-flask>=0.42b0",
     "opentelemetry-instrumentation-requests>=0.42b0",
     "opentelemetry-exporter-otlp-proto-http>=1.21.0",
+    "redis>=7.1.0",
 ]
 
 [dependency-groups]

--- a/template/netwrix-internal-python/redis_signal_handler.py
+++ b/template/netwrix-internal-python/redis_signal_handler.py
@@ -124,7 +124,7 @@ class RedisSignalHandler:
             metadata = metadata or {}
             message_data = {
                 "status": status,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(datetime.UTC).isoformat(),
                 "message": message,
                 "partial_data": str(metadata.get("partial_data", False)).lower(),
                 "objects_count": str(metadata.get("objects_count", 0)),

--- a/template/netwrix-internal-python/redis_signal_handler.py
+++ b/template/netwrix-internal-python/redis_signal_handler.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""
+Redis Signal Handler for graceful stop/pause/resume functionality
+Monitors Redis Streams for control signals from the Core API
+"""
+
+import logging
+import os
+from datetime import datetime
+from typing import Any
+
+import redis
+
+logger = logging.getLogger(__name__)
+
+
+class RedisSignalHandler:
+    """Handle control signals from Redis Streams for scan execution management"""
+
+    CONTROL_STREAM_TTL = 86400  # 24 hours
+
+    def __init__(self, redis_url: str | None = None):
+        """
+        Initialize Redis connection for signal handling
+
+        Args:
+            redis_url: Redis connection URL (default from environment REDIS_URL)
+                      Must be provided either as argument or via REDIS_URL environment variable
+        """
+        self.redis_url = redis_url or os.environ.get("REDIS_URL")
+        if not self.redis_url:
+            logger.error("Redis URL not provided: pass redis_url argument or set REDIS_URL environment variable")
+        self.client = None
+        self._connect()
+
+    def _connect(self) -> None:
+        """
+        Establish connection to Redis
+        """
+        try:
+            # Add socket timeout to prevent hangs
+            # Note: socket_keepalive_options removed as it causes "Invalid argument" errors on some platforms
+            self.client = redis.from_url(
+                self.redis_url,
+                decode_responses=True,
+                socket_connect_timeout=2,  # 2 second connection timeout
+                socket_timeout=2,  # 2 second read/write timeout
+                socket_keepalive=True,  # Enable keepalive without custom options
+            )
+            self.client.ping()
+        except Exception as e:
+            logger.error("Failed to connect to Redis: %s (redis_url=%s)", str(e), self.redis_url)
+            self.client = None
+
+    def check_control_signal(self, execution_id: str, last_message_id: str = "0") -> dict[str, Any] | None:
+        """
+        Check for control signals (STOP, PAUSE, RESUME)
+        Non-blocking read from Redis Stream
+
+        Args:
+            execution_id: The scan execution ID
+            last_message_id: The last message ID read (for stream continuation)
+
+        Returns:
+            Dict with signal data or None if no signal or error
+        """
+        try:
+            control_stream_key = f"scan:control:{execution_id}"
+
+            # Non-blocking read: read latest message after last_message_id
+            # Socket timeout is already configured on the Redis client (2 seconds)
+            messages = self.client.xread(
+                {control_stream_key: last_message_id},
+                count=1,
+                block=0,
+            )
+
+            if not messages or len(messages) == 0:
+                return None
+
+            # Extract message data
+            stream_key, stream_messages = messages[0]
+            if not stream_messages:
+                return None
+
+            message_id, data = stream_messages[0]
+
+            # Include the message ID for tracking
+            data["_id"] = message_id
+
+            return data
+
+        except redis.exceptions.TimeoutError:
+            self._connect()
+            return None
+        except redis.exceptions.RedisError as e:
+            # Attempt to reconnect on Redis errors
+            logger.warning("Redis error reading control signal (execution_id=%s): %s", execution_id, str(e))
+            self._connect()
+            return None
+        except Exception as e:
+            # Log other errors at debug level since some are expected (e.g., timeouts)
+            logger.debug("Error reading control signal (execution_id=%s): %s", execution_id, str(e))
+            return None
+
+    def update_status(
+        self, execution_id: str, status: str, message: str = "", metadata: dict[str, Any] | None = None
+    ) -> str | None:
+        """
+        Update status in Redis Stream for monitoring
+
+        Args:
+            execution_id: The scan execution ID
+            status: Current status (stopping, stopped, etc.)
+            message: Optional status message
+            metadata: Optional metadata dict
+
+        Returns:
+            Message ID if successful, None otherwise
+        """
+        try:
+            status_stream_key = f"scan:status:{execution_id}"
+
+            metadata = metadata or {}
+            message_data = {
+                "status": status,
+                "timestamp": datetime.utcnow().isoformat(),
+                "message": message,
+                "partial_data": str(metadata.get("partial_data", False)).lower(),
+                "objects_count": str(metadata.get("objects_count", 0)),
+                "failed_paths_count": str(metadata.get("failed_paths_count", 0)),
+            }
+
+            message_id = self.client.xadd(status_stream_key, message_data)
+
+            # Set expiration
+            self.client.expire(status_stream_key, self.CONTROL_STREAM_TTL)
+
+            # Trim to keep only last 100 status updates
+            self.client.xtrim(status_stream_key, maxlen=100, approximate=True)
+
+            logger.info("Status updated (execution_id=%s, status=%s)", execution_id, status)
+
+            return message_id
+
+        except redis.exceptions.RedisError as e:
+            # Attempt to reconnect on Redis errors
+            logger.warning("Redis error updating status (execution_id=%s, status=%s): %s", execution_id, status, str(e))
+            self._connect()
+            return None
+        except Exception as e:
+            logger.warning("Failed to update status (execution_id=%s, status=%s): %s", execution_id, status, str(e))
+            return None
+
+    def cleanup_streams(self, execution_id: str) -> bool:
+        """
+        Clean up all streams for a scan execution
+        Should be called when scan is complete
+
+        Args:
+            execution_id: The scan execution ID
+
+        Returns:
+            True if successful, False otherwise
+        """
+        keys_to_delete = [
+            f"scan:control:{execution_id}",
+            f"scan:status:{execution_id}",
+        ]
+
+        try:
+            deleted = self.client.delete(*keys_to_delete)
+            logger.info("Streams cleaned up (execution_id=%s, keys_deleted=%s)", execution_id, deleted)
+            return deleted > 0
+
+        except redis.exceptions.RedisError as e:
+            # Attempt to reconnect and retry cleanup on Redis errors
+            logger.warning(
+                "Redis error during cleanup, attempting reconnect (execution_id=%s): %s", execution_id, str(e)
+            )
+            self._connect()
+            try:
+                deleted = self.client.delete(*keys_to_delete)
+                logger.info(
+                    "Streams cleaned up after reconnect (execution_id=%s, keys_deleted=%s)", execution_id, deleted
+                )
+                return deleted > 0
+            except Exception as retry_e:
+                logger.warning(
+                    "Failed to cleanup streams after reconnect (execution_id=%s): %s", execution_id, str(retry_e)
+                )
+                return False
+        except Exception as e:
+            logger.warning("Failed to cleanup streams (execution_id=%s): %s", execution_id, str(e))
+            return False
+
+    def health_check(self) -> bool:
+        """
+        Check if Redis connection is healthy
+
+        Returns:
+            True if Redis is accessible, False otherwise
+        """
+        try:
+            self.client.ping()
+            return True
+        except redis.exceptions.RedisError:
+            # Attempt to reconnect on Redis errors
+            self._connect()
+
+        try:
+            self.client.ping()
+            return True
+        except Exception as e:
+            logger.warning("Redis health check failed: %s", str(e))
+            return False
+
+    def close(self):
+        """Close Redis connection"""
+        if self.client:
+            try:
+                self.client.close()
+                logger.info("Redis connection closed")
+            except Exception as e:
+                logger.warning("Error closing Redis connection: %s", str(e))
+            finally:
+                self.client = None
+
+    def __enter__(self):
+        """Context manager entry"""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit"""
+        self.close()
+
+
+class ScanControlContext:
+    """
+    Context for managing scan control state
+    Tracks stop and pause signals
+    """
+
+    def __init__(self, execution_id: str, redis_handler: RedisSignalHandler):
+        """
+        Initialize scan control context
+
+        Args:
+            execution_id: The scan execution ID
+            redis_handler: Redis signal handler instance
+        """
+        self.execution_id = execution_id
+        self.redis_handler = redis_handler
+        self.stop_requested = False
+        self.pause_requested = False
+        self.last_signal_id = "0"
+
+    def check_for_signals(self) -> bool:
+        """
+        Check for control signals
+
+        Returns:
+            True if stop signal received, False otherwise
+        """
+        signal = self.redis_handler.check_control_signal(self.execution_id, self.last_signal_id)
+
+        if signal:
+            self.last_signal_id = signal.get("_id", self.last_signal_id)
+            action = signal.get("action")
+
+            if action == "STOP":
+                self.stop_requested = True
+                logger.info("Stop signal received for execution: %s", self.execution_id)
+                return True
+            if action == "PAUSE":
+                self.pause_requested = True
+                logger.info("Pause signal received for execution: %s", self.execution_id)
+                return True
+            if action == "RESUME":
+                self.pause_requested = False
+                logger.info("Resume signal received for execution: %s", self.execution_id)
+                return True
+
+        return self.stop_requested
+
+    def should_stop(self) -> bool:
+        """
+        Check if scanning should stop
+
+        Returns:
+            True if stop was requested, False otherwise
+        """
+        return self.stop_requested
+
+    def should_pause(self) -> bool:
+        """
+        Check if scanning should pause
+
+        Returns:
+            True if pause was requested, False otherwise
+        """
+        return self.pause_requested

--- a/template/netwrix-internal-python/state_manager.py
+++ b/template/netwrix-internal-python/state_manager.py
@@ -1,0 +1,310 @@
+"""
+State Management Framework for Connectors
+
+This module provides a framework for managing scan/sync execution states,
+including stop/pause/resume operations. Connectors can declare their
+supported states and hook into state transition events.
+
+Note: Uses `from __future__ import annotations` for forward type references.
+
+Usage:
+    class MyConnectorHandler:
+        def __init__(self, context):
+            self.state_manager = StateManager(
+                context=context,
+                supported_states={
+                    'stop': True,      # This connector supports stopping
+                    'pause': False,    # This connector doesn't support pausing
+                    'resume': False    # This connector doesn't support resuming
+                }
+            )
+
+        def handle(self, event, context):
+            # Initialize state monitoring
+            self.state_manager.initialize()
+
+            # In main loop:
+            if self.state_manager.should_stop():
+                self.state_manager.shutdown()
+                return result
+"""
+
+from __future__ import annotations
+
+import logging
+
+# Import here to allow for easier mocking in tests
+import threading
+import time
+from collections.abc import Callable
+
+# Add parent directory to sys.path to allow imports
+try:
+    from redis_signal_handler import RedisSignalHandler, ScanControlContext
+except ModuleNotFoundError:
+    # For the function directory structure
+    from function.redis_signal_handler import RedisSignalHandler, ScanControlContext
+
+logger = logging.getLogger(__name__)
+
+
+class StateManager:
+    """
+    Manages connector execution states (stop/pause/resume).
+
+    Provides a unified interface for all connectors to:
+    - Declare supported states
+    - Respond to state change requests
+    - Monitor for state transitions
+    """
+
+    # Valid state transitions
+    VALID_TRANSITIONS: dict[str, list] = {
+        "running": ["stopping", "pausing", "completed", "failed"],
+        "stopping": ["stopped", "failed"],
+        "stopped": [],
+        "pausing": ["paused", "failed"],
+        "paused": ["resuming", "failed", "stopped"],
+        "resuming": ["running", "failed"],
+        "completed": [],
+        "failed": [],
+    }
+
+    # Default supported states (all connectors can support stop)
+    DEFAULT_SUPPORTED_STATES: dict[str, bool] = {
+        "stop": True,  # Halt execution
+        "pause": False,  # Suspend and save state
+        "resume": False,  # Continue from pause
+    }
+
+    def __init__(
+        self,
+        context,
+        supported_states: dict[str, bool] | None = None,
+        signal_check_interval: int = 5,
+    ):
+        """
+        Initialize state manager
+
+        Args:
+            context: Template context object
+            supported_states: Dict of {state: bool} indicating support
+            signal_check_interval: Seconds between signal checks (default 5)
+        """
+        self.context = context
+        self.supported_states = {**self.DEFAULT_SUPPORTED_STATES, **(supported_states or {})}
+        self.signal_check_interval = signal_check_interval
+
+        self.current_state = "running"
+        self.requested_state = None
+        self.redis_handler = None
+        self.control_context = None
+        self.last_signal_check = time.time()
+        self._state_lock = threading.Lock()
+        self._shutdown_event = threading.Event()
+        self._on_state_change_callbacks = []
+
+    def initialize(self) -> bool:
+        """
+        Initialize Redis signal monitoring
+
+        Returns:
+            True if initialization successful, False otherwise
+        """
+        try:
+            # Get execution ID
+            execution_id = self.context.scan_execution_id
+            if not execution_id:
+                logger.warning("No execution ID available, signal monitoring disabled")
+                return False
+
+            # Initialize Redis handler
+            self.redis_handler = RedisSignalHandler()
+
+            if not self.redis_handler.health_check():
+                logger.warning("Redis unavailable, signal monitoring disabled")
+                return False
+
+            # Create control context
+            self.control_context = ScanControlContext(execution_id, self.redis_handler)
+
+            # Update status
+            self.redis_handler.update_status(execution_id, "running")
+
+            logger.info("State manager initialized successfully")
+            return True
+
+        except Exception as e:
+            logger.error("Failed to initialize state manager: %s (%s)", str(e), type(e).__name__)
+            return False
+
+    def check_for_state_changes(self) -> bool:
+        """
+        Check for state change requests from Redis
+
+        Returns:
+            True if stop was requested, False otherwise
+        """
+        if not self.control_context:
+            return False
+
+        current_time = time.time()
+        if current_time - self.last_signal_check < self.signal_check_interval:
+            return False  # Not time to check yet
+
+        self.last_signal_check = current_time
+
+        # Check for incoming signals
+        try:
+            # Socket timeout is configured on Redis client prevent indefinite blocking if it becomes unresponsive.
+            signal = self.control_context.check_for_signals()
+            if signal:
+                if self.control_context.stop_requested:
+                    self.requested_state = "stop"
+                    # Actually transition to stopping state
+                    if self.set_state("stopping"):
+                        logger.info("Stop signal handled, transitioning to stopping state")
+                    return True
+                if self.control_context.pause_requested:
+                    self.requested_state = "pause"
+                    # Actually transition to pausing state
+                    if self.set_state("pausing"):
+                        logger.info("Pause signal handled, transitioning to pausing state")
+                    return False
+        except Exception as e:
+            # just return and allow subsequent calls, in case the issue is transient
+            logger.warning("Error checking state changes: %s (%s)", str(e), type(e).__name__)
+
+        return False
+
+    def should_stop(self) -> bool:
+        """
+        Check if execution should stop
+
+        Returns:
+            True if stop was requested, False otherwise
+        """
+        if not self.supported_states.get("stop", False):
+            logger.info("stop not supported")
+            return False
+
+        self.check_for_state_changes()
+        with self._state_lock:
+            return self.requested_state == "stop"
+
+    def should_pause(self) -> bool:
+        """
+        Check if execution should pause
+
+        Returns:
+            True if pause was requested and supported, False otherwise
+        """
+        if not self.supported_states.get("pause", False):
+            logger.info("pause not supported")
+            return False
+
+        self.check_for_state_changes()
+        with self._state_lock:
+            return self.requested_state == "pause"
+
+    def set_state(self, new_state: str) -> bool:
+        """
+        Transition to a new state
+
+        Args:
+            new_state: Target state name
+
+        Returns:
+            True if transition is valid and successful, False otherwise
+        """
+        with self._state_lock:
+            if new_state == self.current_state:
+                return True
+
+            valid_transitions = self.VALID_TRANSITIONS.get(self.current_state, [])
+
+            if new_state not in valid_transitions:
+                logger.warning("Invalid state transition from %s to %s", self.current_state, new_state)
+                return False
+
+            old_state = self.current_state
+            self.current_state = new_state
+
+            logger.info("State transitioned from %s to %s", old_state, new_state)
+
+        # Call callbacks outside lock to avoid deadlocks
+        self._trigger_state_change_callbacks(old_state, new_state)
+        return True
+
+    def on_state_change(self, callback: Callable[[str, str], None]) -> None:
+        """
+        Register callback for state change events
+
+        Args:
+            callback: Function(old_state, new_state) to call on state changes
+        """
+        self._on_state_change_callbacks.append(callback)
+
+    def _trigger_state_change_callbacks(self, old_state: str, new_state: str):
+        """Trigger all registered callbacks for state change"""
+        for callback in self._on_state_change_callbacks:
+            try:
+                callback(old_state, new_state)
+            except Exception as e:
+                logger.error("Error in state change callback: %s (%s)", str(e), type(e).__name__)
+
+    def shutdown(self, final_status: str = "stopped") -> bool:
+        """
+        Gracefully shut down and transition to final state
+
+        Args:
+            final_status: Final state ('stopped', 'completed', 'failed')
+
+        Returns:
+            True if shutdown successful, False otherwise
+        """
+        try:
+            # Transition state
+            if not self.set_state(final_status):
+                logger.warning("Could not transition to final state: %s", final_status)
+                return False
+
+            # Update Redis status
+            if self.redis_handler:
+                execution_id = self.context.scan_execution_id
+                self.redis_handler.update_status(
+                    execution_id, final_status, "Execution stopped", {"partial_data": final_status == "stopped"}
+                )
+
+                # Cleanup streams
+                self.redis_handler.cleanup_streams(execution_id)
+
+            self._shutdown_event.set()
+            logger.info("State manager shutdown with status: %s", final_status)
+            return True
+
+        except Exception as e:
+            logger.error("Error during shutdown: %s (%s)", str(e), type(e).__name__)
+            return False
+
+    def is_shutdown(self) -> bool:
+        """Check if shutdown has been initiated"""
+        return self._shutdown_event.is_set()
+
+    def supports_state(self, state: str) -> bool:
+        """Check if connector supports a state"""
+        return self.supported_states.get(state, False)
+
+    def get_supported_states(self) -> dict[str, bool]:
+        """Get all supported states"""
+        return self.supported_states.copy()
+
+    def get_current_state(self) -> str:
+        """Get current execution state"""
+        with self._state_lock:
+            return self.current_state
+
+    def close(self):
+        """Clean up resources"""
+        if self.redis_handler:
+            self.redis_handler.close()

--- a/template/netwrix-internal-python/uv.lock
+++ b/template/netwrix-internal-python/uv.lock
@@ -220,6 +220,7 @@ dependencies = [
     { name = "opentelemetry-instrumentation-flask" },
     { name = "opentelemetry-instrumentation-requests" },
     { name = "opentelemetry-sdk" },
+    { name = "redis" },
     { name = "requests" },
     { name = "waitress" },
 ]
@@ -238,6 +239,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-flask", specifier = ">=0.42b0" },
     { name = "opentelemetry-instrumentation-requests", specifier = ">=0.42b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.21.0" },
+    { name = "redis", specifier = ">=7.1.0" },
     { name = "requests", specifier = ">=2.33.0" },
     { name = "waitress", specifier = ">=3.0.2" },
 ]
@@ -423,6 +425,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
     { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
     { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
+]
+
+[[package]]
+name = "redis"
+version = "7.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
 ]
 
 [[package]]

--- a/template/netwrix-python/index.py
+++ b/template/netwrix-python/index.py
@@ -374,33 +374,30 @@ class Context:
         if not self.scan_id:
             raise ValueError("scan_id must be set to retrieve connector state")
 
-        try:
-            # Build headers with caller context information
-            headers = {"Content-Type": "application/json", **self.get_caller_headers()}
+        # Build headers with caller context information
+        headers = {"Content-Type": "application/json", **self.get_caller_headers()}
 
-            # Get service URL for connector-state
-            service_name = os.getenv("CONNECTOR_STATE_FUNCTION", "connector-state")
-            url = get_service_url(service_name)
+        # Get service URL for connector-state
+        service_name = os.getenv("CONNECTOR_STATE_FUNCTION", "connector-state")
+        url = get_service_url(service_name)
 
-            response = requests.get(
-                url,
-                params={"scanId": self.scan_id},
-                headers=headers,
-                timeout=30,
-            )
+        response = requests.get(
+            url,
+            params={"scanId": self.scan_id},
+            headers=headers,
+            timeout=30,
+        )
 
-            if response.status_code == 200:
-                result = response.json()
-                if result.get("success"):
-                    self.log.info("Retrieved connector state successfully", key_count=len(result.get("data", {})))
-                    return result.get("data", {})
-                error_msg = f"Failed to retrieve connector state: {result.get('error', 'Unknown error')}"
-                raise Exception(error_msg)
-
-            error_msg = f"Status {response.status_code}: {response.text}"
+        if response.status_code == 200:
+            result = response.json()
+            if result.get("success"):
+                self.log.info("Retrieved connector state successfully", key_count=len(result.get("data", {})))
+                return result.get("data", {})
+            error_msg = f"Failed to retrieve connector state: {result.get('error', 'Unknown error')}"
             raise Exception(error_msg)
-        except Exception:
-            raise
+
+        error_msg = f"Status {response.status_code}: {response.text}"
+        raise Exception(error_msg)
 
     def delete_connector_state(self, names: list[str] | None = None) -> tuple[bool, str | None]:
         """
@@ -656,8 +653,9 @@ class Context:
         """
         try:
             # Query Postgres for scan execution status via app-data-query function
+            safe_scan_execution_id = scan_execution_id.replace("'", "''")
             query = (
-                f"SELECT id, status, completed_objects FROM scan_executions WHERE id = '{scan_execution_id}' LIMIT 1"
+                f"SELECT id, status, completed_objects FROM scan_executions WHERE id = '{safe_scan_execution_id}' LIMIT 1"
             )
             payload = {"query": query}
 

--- a/template/netwrix-python/index.py
+++ b/template/netwrix-python/index.py
@@ -654,9 +654,7 @@ class Context:
         try:
             # Query Postgres for scan execution status via app-data-query function
             safe_scan_execution_id = scan_execution_id.replace("'", "''")
-            query = (
-                f"SELECT id, status, completed_objects FROM scan_executions WHERE id = '{safe_scan_execution_id}' LIMIT 1"
-            )
+            query = f"SELECT id, status, completed_objects FROM scan_executions WHERE id = '{safe_scan_execution_id}' LIMIT 1"
             payload = {"query": query}
 
             # Build headers with caller context information

--- a/template/netwrix-python/redis_signal_handler.py
+++ b/template/netwrix-python/redis_signal_handler.py
@@ -124,7 +124,7 @@ class RedisSignalHandler:
             metadata = metadata or {}
             message_data = {
                 "status": status,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(datetime.UTC).isoformat(),
                 "message": message,
                 "partial_data": str(metadata.get("partial_data", False)).lower(),
                 "objects_count": str(metadata.get("objects_count", 0)),


### PR DESCRIPTION
Add StateManager and RedisSignalHandler for graceful stop/pause/resume of scan executions via Redis Streams. Add connector state methods (get/set/delete) and get_prior_execution to Context. Switch logging handler from WSGI to stderr for job mode compatibility. Add redis dependency to pyproject.toml. 

Also fixes SQL injection in get_prior_execution and deprecated datetime.utcnow() usage in both Python templates. 