### PR TITLE
fix(templates): use timezone.utc instead of datetime.UTC in redis signal handler

### DIFF
--- a/template/netwrix-internal-python/redis_signal_handler.py
+++ b/template/netwrix-internal-python/redis_signal_handler.py
@@ -6,7 +6,7 @@ Monitors Redis Streams for control signals from the Core API
 
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 import redis
@@ -124,7 +124,7 @@ class RedisSignalHandler:
             metadata = metadata or {}
             message_data = {
                 "status": status,
-                "timestamp": datetime.now(datetime.UTC).isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "message": message,
                 "partial_data": str(metadata.get("partial_data", False)).lower(),
                 "objects_count": str(metadata.get("objects_count", 0)),

--- a/template/netwrix-internal-python/redis_signal_handler.py
+++ b/template/netwrix-internal-python/redis_signal_handler.py
@@ -124,7 +124,7 @@ class RedisSignalHandler:
             metadata = metadata or {}
             message_data = {
                 "status": status,
-                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),  # noqa: UP017 -- timezone.utc is used for Python <3.11 compatibility
                 "message": message,
                 "partial_data": str(metadata.get("partial_data", False)).lower(),
                 "objects_count": str(metadata.get("objects_count", 0)),

--- a/template/netwrix-python/redis_signal_handler.py
+++ b/template/netwrix-python/redis_signal_handler.py
@@ -6,7 +6,7 @@ Monitors Redis Streams for control signals from the Core API
 
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 import redis
@@ -124,7 +124,7 @@ class RedisSignalHandler:
             metadata = metadata or {}
             message_data = {
                 "status": status,
-                "timestamp": datetime.now(datetime.UTC).isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "message": message,
                 "partial_data": str(metadata.get("partial_data", False)).lower(),
                 "objects_count": str(metadata.get("objects_count", 0)),

--- a/template/netwrix-python/redis_signal_handler.py
+++ b/template/netwrix-python/redis_signal_handler.py
@@ -124,7 +124,7 @@ class RedisSignalHandler:
             metadata = metadata or {}
             message_data = {
                 "status": status,
-                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),  # noqa: UP017 -- timezone.utc is used for Python <3.11 compatibility
                 "message": message,
                 "partial_data": str(metadata.get("partial_data", False)).lower(),
                 "objects_count": str(metadata.get("objects_count", 0)),


### PR DESCRIPTION
datetime.UTC was introduced in Python 3.11; timezone.utc is compatible with older versions.