### PR TITLE
fix(templates): derive exit code from handler response and improve test reliability

### DIFF
--- a/template/netwrix-csharp/ConnectorFramework.Tests/CrawlRunOrchestratorPauseResumeTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/CrawlRunOrchestratorPauseResumeTests.cs
@@ -60,7 +60,14 @@ public class CrawlRunOrchestratorPauseResumeTests
         processorFactory.HoldNextCrawl();
         var run1Task = orchestrator.RunAsync(request, cts.Token);
 
-        await processorFactory.WaitForCallAsync(cts.Token); // root task started (still held in Crawl)
+        // Race RunAsync against the signal wait so that a fault in RunAsync (e.g.
+        // OptionsValidationException thrown before any worker starts) surfaces immediately
+        // rather than silently disappearing and leaving the test to time out.
+        var signalWait1 = processorFactory.WaitForCallAsync(cts.Token);
+        await Task.WhenAny(run1Task, signalWait1);
+        if (run1Task.IsCompleted) await run1Task; // re-throw any fault
+        await signalWait1; // root task started (still held in Crawl)
+
         signalSource.Send(CrawlRunSignal.Pause);             // enqueue Pause before root completes
         processorFactory.UnblockCrawl();                     // release root → children enqueued, orchestrator sees Pause next
 
@@ -109,7 +116,11 @@ public class CrawlRunOrchestratorPauseResumeTests
         // Act
         var runTask = orchestrator.RunAsync(request, cts.Token);
 
-        await processorFactory.WaitForCallAsync(cts.Token); // root task started
+        var signalWait = processorFactory.WaitForCallAsync(cts.Token);
+        await Task.WhenAny(runTask, signalWait);
+        if (runTask.IsCompleted) await runTask; // re-throw any fault
+        await signalWait; // root task started
+
         signalSource.Send(CrawlRunSignal.Stop);
 
         var exitReason = await runTask;

--- a/template/netwrix-csharp/ConnectorFramework.Tests/ProgramTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/ProgramTests.cs
@@ -134,6 +134,48 @@ public class ProgramTests
         }
     }
 
+    // ── DeriveExitCode ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DeriveExitCode_Returns0_WhenStatusCodeIs200()
+    {
+        Assert.Equal(0, Program.DeriveExitCode("""{"statusCode":200,"body":{}}"""));
+    }
+
+    [Fact]
+    public void DeriveExitCode_Returns1_WhenStatusCodeIs400()
+    {
+        // FunctionContext.ErrorResponse(clientError: true, ...) sets statusCode 400.
+        Assert.Equal(1, Program.DeriveExitCode("""{"statusCode":400,"body":{"error":"bad input"}}"""));
+    }
+
+    [Fact]
+    public void DeriveExitCode_Returns1_WhenStatusCodeIs500()
+    {
+        // FunctionContext.ErrorResponse(clientError: false, ...) sets statusCode 500.
+        Assert.Equal(1, Program.DeriveExitCode("""{"statusCode":500,"body":{"error":"internal error"}}"""));
+    }
+
+    [Fact]
+    public void DeriveExitCode_Returns0_WhenStatusCodeFieldIsAbsent()
+    {
+        // Handlers that return a plain object without statusCode are treated as success.
+        Assert.Equal(0, Program.DeriveExitCode("{}"));
+    }
+
+    [Fact]
+    public void DeriveExitCode_Returns0_WhenStatusCodeIs399()
+    {
+        // Boundary: 399 is below the error threshold.
+        Assert.Equal(0, Program.DeriveExitCode("""{"statusCode":399}"""));
+    }
+
+    [Fact]
+    public void DeriveExitCode_Returns1_WhenStatusCodeIs401()
+    {
+        Assert.Equal(1, Program.DeriveExitCode("""{"statusCode":401}"""));
+    }
+
     // ── ValidateSecretMappings ────────────────────────────────────────────────
 
     [Fact]

--- a/template/netwrix-csharp/ConnectorFramework/Program.cs
+++ b/template/netwrix-csharp/ConnectorFramework/Program.cs
@@ -186,14 +186,21 @@ internal static class Program
                 }
                 await context.FlushTablesAsync();
 
+                // Write the result JSON to stdout so connector-api can capture it as logs.
+                var resultJson = JsonSerializer.Serialize(result);
+                Console.WriteLine(resultJson);
+
+                exitCode = DeriveExitCode(resultJson);
+
+                var metricStatus = exitCode == 0 ? "succeeded" : "failed";
                 ConnectorMetrics.ExecutionDuration.Record(
                     executionStopwatch.Elapsed.TotalSeconds,
-                    new KeyValuePair<string, object?>("status", "succeeded"));
+                    new KeyValuePair<string, object?>("status", metricStatus));
 
-                jobActivity?.SetStatus(ActivityStatusCode.Ok);
-
-                Console.WriteLine(JsonSerializer.Serialize(result));
-                exitCode = 0;
+                if (exitCode == 0)
+                    jobActivity?.SetStatus(ActivityStatusCode.Ok);
+                else
+                    jobActivity?.SetStatus(ActivityStatusCode.Error, "Handler returned error statusCode");
             }
         }
         catch (Exception ex)
@@ -516,6 +523,22 @@ internal static class Program
         await request.Body.CopyToAsync(ms);
         request.Body.Position = 0;
         return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Derives the process exit code from the serialized result JSON returned by a connector handler.
+    /// Handlers signal failure by returning <see cref="FunctionContext.ErrorResponse"/>, which sets
+    /// <c>statusCode</c> to 400 (client error) or 500 (server error). Without this check the process
+    /// would always exit 0, causing connector-api — which evaluates job success solely via pod exit code
+    /// — to report a completed job even when the connector detected an error (e.g. the SPO connector
+    /// catching an Azure AD or certificate exception and returning ValidationResult.Error).
+    /// Returns 1 when <c>statusCode</c> ≥ 400, 0 otherwise (including when the field is absent).
+    /// </summary>
+    internal static int DeriveExitCode(string resultJson)
+    {
+        using var doc = JsonDocument.Parse(resultJson);
+        return doc.RootElement.TryGetProperty("statusCode", out var statusCodeEl)
+            && statusCodeEl.GetInt32() >= 400 ? 1 : 0;
     }
 
     internal static string BuildRequestPath()


### PR DESCRIPTION
AB#417810

## Summary

- Adds `DeriveExitCode` to `Program.cs`: connector handlers signal failure via `FunctionContext.ErrorResponse`, which sets `statusCode` 400/500 in the result JSON. Previously the job process always exited 0, causing `connector-api` to report success even when the connector detected an error. Exit code, metrics status, and activity status now all reflect the actual outcome.
- Races `RunAsync` against the signal wait in pause/resume tests so that a fault (e.g. `OptionsValidationException` thrown before any worker starts) re-throws immediately rather than silently disappearing and causing a test timeout.

## Test plan

- [x] `dotnet test template/netwrix-csharp/ConnectorFramework.Tests/ConnectorFramework.Tests.csproj` passes (includes 6 new `DeriveExitCode` unit tests)
- [x] Verify job pods exit non-zero when a connector handler returns `ErrorResponse` (e.g. validation failure with an invalid certificate)

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>