### PR TITLE
fix(templates): C# connector template bug fixes — FlushBuffer + batched DELETE requests

### DIFF
--- a/template/netwrix-csharp/ConnectorFramework.Tests/AACorePlatformFacadeTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/AACorePlatformFacadeTests.cs
@@ -58,30 +58,47 @@ public class AACorePlatformFacadeTests
     }
 
     [Fact]
-    public async Task UploadSiTSchemaRecords_WhenIsFinalTrue_FlushesWriter()
+    public async Task UploadSiTSchemaRecords_IsFinalTrue_FlushesBuffersNotTables()
     {
+        // isFinal=true triggers a non-closing buffer flush for incremental ClickHouse writes,
+        // NOT the channel-closing FlushTablesAsync.
         var writerMock = WriterMock();
         var facade = CreateFacade(writerMock.Object);
 
         await facade.UploadSiTSchemaRecords(new CrawlContext(), "schema_table", [], isFinal: true);
 
-        writerMock.Verify(w => w.FlushTablesAsync(CancellationToken.None), Times.Once);
+        writerMock.Verify(w => w.FlushBuffers(It.IsAny<CancellationToken>()), Times.Once);
+        writerMock.Verify(w => w.FlushTablesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public async Task UploadSiTSchemaRecords_ConcurrentCalls_DoNotThrowAndSaveAllEntities()
+    public async Task UploadSiTSchemaRecords_IsFinalFalse_NeitherFlushes()
     {
+        var writerMock = WriterMock();
+        var facade = CreateFacade(writerMock.Object);
+
+        await facade.UploadSiTSchemaRecords(new CrawlContext(), "schema_table", [], isFinal: false);
+
+        writerMock.Verify(w => w.FlushBuffers(It.IsAny<CancellationToken>()), Times.Never);
+        writerMock.Verify(w => w.FlushTablesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UploadSiTSchemaRecords_ConcurrentCallsWithIsFinalTrue_SavesAllEntities()
+    {
+        // Regression: concurrent workers each passing isFinal=true must not close channels or
+        // cause data loss for workers still queued behind _writeLock.
         var writerMock = WriterMock();
         var facade = CreateFacade(writerMock.Object);
         var entity = new JsonObject { ["id"] = "x" };
 
         var tasks = Enumerable.Range(0, 10).Select(_ =>
-            facade.UploadSiTSchemaRecords(new CrawlContext(), "permissions", [entity], isFinal: false));
+            facade.UploadSiTSchemaRecords(new CrawlContext(), "memberships", [entity], isFinal: true));
 
-        // Should complete without throwing InvalidOperationException from BatchManager's single-writer guard
         await Task.WhenAll(tasks);
 
-        writerMock.Verify(w => w.SaveObject("permissions", entity, true), Times.Exactly(10));
+        writerMock.Verify(w => w.SaveObject("memberships", entity, true), Times.Exactly(10));
+        writerMock.Verify(w => w.FlushTablesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ── UploadActivityRecords ────────────────────────────────────────────────

--- a/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateStorageTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateStorageTests.cs
@@ -17,11 +17,13 @@ public class ConnectorStateStorageTests
         => new("POST", "/", new Dictionary<string, string>(), null,
             new ExecutionContext(ScanId: scanId, ScanExecutionId: null, SourceId: null, SourceType: null, SourceVersion: null, FunctionType: null));
 
-    private static ConnectorStateStorage CreateStorage(IHttpClientFactory factory, string? scanId = "scan-test")
-        => new(MakeRequest(scanId), factory, NullLogger<ConnectorStateStorage>.Instance);
+    private static ConnectorStateClient CreateClient(HttpMessageHandler handler)
+        => new(
+            new HttpClient(handler) { BaseAddress = new Uri("http://connector-state/") },
+            NullLogger<ConnectorStateClient>.Instance);
 
-    /// <summary>Returns a factory that replies to every request with the same body/status.</summary>
-    private static (Mock<HttpMessageHandler> Handler, IHttpClientFactory Factory) CreateFactory(
+    /// <summary>Returns a client that replies to every request with the same body/status.</summary>
+    private static ConnectorStateClient CreateClient(
         string responseBody,
         HttpStatusCode statusCode = HttpStatusCode.OK)
     {
@@ -37,15 +39,11 @@ public class ConnectorStateStorageTests
                 {
                     Content = new StringContent(responseBody, Encoding.UTF8, "application/json"),
                 }));
-
-        // Return a fresh HttpClient on each call — the real IHttpClientFactory does the same,
-        // and it prevents ObjectDisposedException when a second call is made after the first
-        // disposes its client via 'using var'.
-        var factoryMock = new Mock<IHttpClientFactory>();
-        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>()))
-            .Returns(() => new HttpClient(handlerMock.Object));
-        return (handlerMock, factoryMock.Object);
+        return CreateClient(handlerMock.Object);
     }
+
+    private static ConnectorStateStorage CreateStorage(ConnectorStateClient client, string? scanId = "scan-test")
+        => new(MakeRequest(scanId), client, NullLogger<ConnectorStateStorage>.Instance);
 
     private static string StateResponse(Dictionary<string, string> data)
         => JsonSerializer.Serialize(new { success = true, data });
@@ -58,8 +56,7 @@ public class ConnectorStateStorageTests
     [Fact]
     public async Task TryGetAsync_ReturnsNotFound_WhenKeyAbsent()
     {
-        var (_, factory) = CreateFactory(EmptyStateResponse());
-        var storage = CreateStorage(factory);
+        var storage = CreateStorage(CreateClient(EmptyStateResponse()));
 
         var result = await storage.TryGetAsync<string>("missing");
 
@@ -73,8 +70,7 @@ public class ConnectorStateStorageTests
         {
             ["myKey"] = "\"hello\"",
         };
-        var (_, factory) = CreateFactory(StateResponse(stateData));
-        var storage = CreateStorage(factory);
+        var storage = CreateStorage(CreateClient(StateResponse(stateData)));
 
         var result = await storage.TryGetAsync<string>("myKey");
 
@@ -86,20 +82,28 @@ public class ConnectorStateStorageTests
     [Fact]
     public async Task TryGetAsync_ReturnsNotFound_WhenScanIdIsNull()
     {
-        var factoryMock = new Mock<IHttpClientFactory>();
-        var storage = CreateStorage(factoryMock.Object, scanId: null);
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>((_, _) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        var storage = CreateStorage(CreateClient(handlerMock.Object), scanId: null);
 
         var result = await storage.TryGetAsync<string>("anyKey");
 
         Assert.False(result.IsSuccess);
-        factoryMock.Verify(f => f.CreateClient(It.IsAny<string>()), Times.Never);
+        handlerMock.Protected().Verify(
+            "SendAsync", Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
     }
 
     [Fact]
     public async Task TryGetAsync_ThrowsStorageException_OnHttpError()
     {
-        var (_, factory) = CreateFactory("{}", HttpStatusCode.InternalServerError);
-        var storage = CreateStorage(factory);
+        var storage = CreateStorage(CreateClient("{}", HttpStatusCode.InternalServerError));
 
         await Assert.ThrowsAsync<StateStorageException>(() => storage.TryGetAsync<string>("myKey"));
     }
@@ -120,11 +124,7 @@ public class ConnectorStateStorageTests
                 capturedBody = await req.Content!.ReadAsByteArrayAsync();
             })
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
-
-        var factoryMock = new Mock<IHttpClientFactory>();
-        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>()))
-            .Returns(() => new HttpClient(handlerMock.Object));
-        var storage = CreateStorage(factoryMock.Object);
+        var storage = CreateStorage(CreateClient(handlerMock.Object));
 
         await storage.SetAsync("cursor", "page-5");
 
@@ -138,12 +138,21 @@ public class ConnectorStateStorageTests
     [Fact]
     public async Task SetAsync_IsNoOp_WhenScanIdIsNull()
     {
-        var factoryMock = new Mock<IHttpClientFactory>();
-        var storage = CreateStorage(factoryMock.Object, scanId: null);
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>((_, _) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        var storage = CreateStorage(CreateClient(handlerMock.Object), scanId: null);
 
         await storage.SetAsync("key", "value");
 
-        factoryMock.Verify(f => f.CreateClient(It.IsAny<string>()), Times.Never);
+        handlerMock.Protected().Verify(
+            "SendAsync", Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
     }
 
     // ── SetIfMatchAsync ───────────────────────────────────────────────────────
@@ -162,11 +171,7 @@ public class ConnectorStateStorageTests
                 capturedBody = await req.Content!.ReadAsByteArrayAsync();
             })
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
-
-        var factoryMock = new Mock<IHttpClientFactory>();
-        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>()))
-            .Returns(() => new HttpClient(handlerMock.Object));
-        var storage = CreateStorage(factoryMock.Object);
+        var storage = CreateStorage(CreateClient(handlerMock.Object));
 
         var result = await storage.SetIfMatchAsync("bookmark", "value-new", "any-etag");
 
@@ -195,11 +200,7 @@ public class ConnectorStateStorageTests
                 deleteUrl = req.RequestUri!.ToString();
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
             });
-
-        var factoryMock = new Mock<IHttpClientFactory>();
-        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>()))
-            .Returns(() => new HttpClient(handlerMock.Object));
-        var storage = CreateStorage(factoryMock.Object);
+        var storage = CreateStorage(CreateClient(handlerMock.Object));
 
         var deleted = await storage.DeleteAsync("target");
 
@@ -207,6 +208,30 @@ public class ConnectorStateStorageTests
         Assert.Equal(HttpMethod.Delete, deleteMethod);
         Assert.NotNull(deleteUrl);
         Assert.Contains("name=target", deleteUrl);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_PropagatesCancellation()
+    {
+        // Before the OperationCanceledException fix, the catch (Exception ex) block in each HTTP
+        // method would wrap cancellation as StateStorageException, hiding the cancellation signal.
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>((_, ct) =>
+            {
+                ct.ThrowIfCancellationRequested();
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            });
+        var storage = CreateStorage(CreateClient(handlerMock.Object));
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => storage.DeleteAsync("key", cts.Token));
     }
 
     // ── DeleteAllAsync ────────────────────────────────────────────────────────
@@ -220,7 +245,7 @@ public class ConnectorStateStorageTests
             ["source/abc/cursor"] = "\"v2\"",
             ["other/key"] = "\"v3\"",
         };
-        string? deleteUrl = null;
+        var deleteRequests = new List<string>();
         var handlerMock = new Mock<HttpMessageHandler>();
         var callIndex = 0;
         handlerMock.Protected()
@@ -236,22 +261,135 @@ public class ConnectorStateStorageTests
                         Content = new StringContent(StateResponse(stateData), Encoding.UTF8, "application/json"),
                     });
                 }
-                deleteUrl = req.RequestUri!.ToString();
+                deleteRequests.Add(req.RequestUri!.ToString());
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
             });
-
-        var factoryMock = new Mock<IHttpClientFactory>();
-        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>()))
-            .Returns(() => new HttpClient(handlerMock.Object));
-        var storage = CreateStorage(factoryMock.Object);
+        var storage = CreateStorage(CreateClient(handlerMock.Object));
 
         await storage.DeleteAllAsync("source/abc");
 
-        Assert.NotNull(deleteUrl);
-        Assert.True(deleteUrl!.Contains("bookmark") && deleteUrl.Contains("cursor"),
+        Assert.Single(deleteRequests);
+        var deleteUrl = deleteRequests[0];
+        Assert.True(deleteUrl.Contains("bookmark") && deleteUrl.Contains("cursor"),
             $"Expected both bookmark and cursor in DELETE url: {deleteUrl}");
         Assert.DoesNotContain("other%2Fkey", deleteUrl);
         Assert.DoesNotContain("other/key", deleteUrl);
+    }
+
+    [Fact]
+    public async Task DeleteAllAsync_BatchesDeleteRequests_WhenUrlLengthWouldExceedLimit()
+    {
+        // ConnectorStateClient.DeleteManyAsync batches by URL length (MaxDeleteQueryLength = 4,000)
+        // rather than by a fixed key count. This prevents UriFormatException for long key names
+        // and respects proxy URL size limits.
+        //
+        // Key format: "source/abc/item-NNNNNN" (22 chars, URL-encoded to 26 chars due to '/' → '%2F').
+        // Per-key query segment: "&name=" (6) + 26 = 32 chars.
+        // Base: "?scanId=scan-test" = 18 chars. Available per batch: 4,000 - 18 = 3,982.
+        // Keys per batch: floor(3,982 / 32) = 124. For 300 keys: ceil(300 / 124) = 3 batches.
+        const int keyCount = 300;
+        const string prefix = "source/abc";
+
+        var stateData = Enumerable.Range(0, keyCount)
+            .ToDictionary(i => $"{prefix}/item-{i:D6}", _ => "\"v\"");
+
+        var deleteRequests = new List<string>();
+        var handlerMock = new Mock<HttpMessageHandler>();
+        var callIndex = 0;
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>((req, _) =>
+            {
+                if (callIndex++ == 0)
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(StateResponse(stateData), Encoding.UTF8, "application/json"),
+                    });
+                }
+                deleteRequests.Add(req.RequestUri!.ToString());
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            });
+        var storage = CreateStorage(CreateClient(handlerMock.Object));
+
+        await storage.DeleteAllAsync(prefix);
+
+        Assert.Equal(3, deleteRequests.Count);
+
+        // No single batch URL's query portion should exceed MaxDeleteQueryLength
+        const string baseUrl = "http://connector-state/";
+        foreach (var url in deleteRequests)
+        {
+            var queryLength = url.Length - baseUrl.Length;
+            Assert.True(
+                queryLength <= ConnectorStateClient.MaxDeleteQueryLength,
+                $"Batch query exceeded {ConnectorStateClient.MaxDeleteQueryLength} chars ({queryLength}): {url[..Math.Min(200, url.Length)]}");
+        }
+
+        // Every key must appear in exactly one batch
+        var allDeletedKeys = deleteRequests
+            .SelectMany(url => url.Split('&')
+                .Where(p => p.StartsWith("name=", StringComparison.Ordinal))
+                .Select(p => Uri.UnescapeDataString(p["name=".Length..])))
+            .ToHashSet();
+        Assert.Equal(keyCount, allDeletedKeys.Count);
+        Assert.All(stateData.Keys, k => Assert.Contains(k, allDeletedKeys));
+    }
+
+    [Fact]
+    public async Task DeleteAllAsync_CompletesSafely_WhenTotalUrlWouldExceedNetUriLimit()
+    {
+        // Without URL-length-based batching, a single DELETE with these 100 keys would produce
+        // a query string of ~72,018 chars, exceeding .NET's ~65,519-char URI limit and throwing
+        // System.UriFormatException: Invalid URI: The Uri string is too long.
+        //
+        // Key format: "source/abc/" (11 chars) + 694 'a's + 5-digit index = 710 chars.
+        // URL-encoded: "source%2Fabc%2F" (15) + 694 + 5 = 714 chars.
+        // Per-key query segment: "&name=" (6) + 714 = 720 chars.
+        // 100 keys unbatched: 18 + 100 × 720 = 72,018 chars → UriFormatException.
+        // With MaxDeleteQueryLength = 4,000: floor((4,000-18)/720) = 5 keys/batch → 20 batches.
+        const int keyCount = 100;
+        const string prefix = "source/abc";
+
+        var stateData = Enumerable.Range(0, keyCount)
+            .ToDictionary(i => $"{prefix}/{new string('a', 694)}{i:D5}", _ => "\"v\"");
+
+        var deleteRequests = new List<string>();
+        var handlerMock = new Mock<HttpMessageHandler>();
+        var callIndex = 0;
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>((req, _) =>
+            {
+                if (callIndex++ == 0)
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(StateResponse(stateData), Encoding.UTF8, "application/json"),
+                    });
+                }
+                deleteRequests.Add(req.RequestUri!.ToString());
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            });
+        var storage = CreateStorage(CreateClient(handlerMock.Object));
+
+        await storage.DeleteAllAsync(prefix);
+
+        // Completed without UriFormatException — multiple batches were required
+        Assert.True(deleteRequests.Count > 1, "Expected more than one DELETE batch for long-key workload");
+
+        // Every key must appear in exactly one batch
+        var allDeletedKeys = deleteRequests
+            .SelectMany(url => url.Split('&')
+                .Where(p => p.StartsWith("name=", StringComparison.Ordinal))
+                .Select(p => Uri.UnescapeDataString(p["name=".Length..])))
+            .ToHashSet();
+        Assert.Equal(keyCount, allDeletedKeys.Count);
+        Assert.All(stateData.Keys, k => Assert.Contains(k, allDeletedKeys));
     }
 
     // ── ListAllKeysAsync ──────────────────────────────────────────────────────
@@ -265,8 +403,7 @@ public class ConnectorStateStorageTests
             ["a/y"] = "\"2\"",
             ["b/z"] = "\"3\"",
         };
-        var (_, factory) = CreateFactory(StateResponse(stateData));
-        var storage = CreateStorage(factory);
+        var storage = CreateStorage(CreateClient(StateResponse(stateData)));
 
         var keys = new List<string>();
         await foreach (var k in storage.ListAllKeysAsync("a"))
@@ -280,8 +417,14 @@ public class ConnectorStateStorageTests
     [Fact]
     public async Task ListAllKeysAsync_ReturnsEmpty_WhenScanIdIsNull()
     {
-        var factoryMock = new Mock<IHttpClientFactory>();
-        var storage = CreateStorage(factoryMock.Object, scanId: null);
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>((_, _) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        var storage = CreateStorage(CreateClient(handlerMock.Object), scanId: null);
 
         var keys = new List<string>();
         await foreach (var k in storage.ListAllKeysAsync())
@@ -290,7 +433,10 @@ public class ConnectorStateStorageTests
         }
 
         Assert.Empty(keys);
-        factoryMock.Verify(f => f.CreateClient(It.IsAny<string>()), Times.Never);
+        handlerMock.Protected().Verify(
+            "SendAsync", Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
     }
 
     // ── ListKeysAsync ─────────────────────────────────────────────────────────
@@ -305,8 +451,7 @@ public class ConnectorStateStorageTests
             ["src/tenant/other/bookmark"] = "\"v\"",
             ["src/tenant/bookmark"] = "\"v\"", // depth=1 from src/tenant
         };
-        var (_, factory) = CreateFactory(StateResponse(stateData));
-        var storage = CreateStorage(factory);
+        var storage = CreateStorage(CreateClient(StateResponse(stateData)));
 
         var depth1 = new List<string>();
         await foreach (var k in storage.ListKeysAsync("src/tenant", depth: 1))

--- a/template/netwrix-csharp/ConnectorFramework.Tests/CrawlRunOrchestratorPauseResumeTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/CrawlRunOrchestratorPauseResumeTests.cs
@@ -65,7 +65,11 @@ public class CrawlRunOrchestratorPauseResumeTests
         // rather than silently disappearing and leaving the test to time out.
         var signalWait1 = processorFactory.WaitForCallAsync(cts.Token);
         await Task.WhenAny(run1Task, signalWait1);
-        if (run1Task.IsCompleted) await run1Task; // re-throw any fault
+        if (run1Task.IsCompleted)
+        {
+            await run1Task; // re-throw any fault
+        }
+
         await signalWait1; // root task started (still held in Crawl)
 
         signalSource.Send(CrawlRunSignal.Pause);             // enqueue Pause before root completes
@@ -118,7 +122,11 @@ public class CrawlRunOrchestratorPauseResumeTests
 
         var signalWait = processorFactory.WaitForCallAsync(cts.Token);
         await Task.WhenAny(runTask, signalWait);
-        if (runTask.IsCompleted) await runTask; // re-throw any fault
+        if (runTask.IsCompleted)
+        {
+            await runTask; // re-throw any fault
+        }
+
         await signalWait; // root task started
 
         signalSource.Send(CrawlRunSignal.Stop);

--- a/template/netwrix-csharp/ConnectorFramework/AACorePlatformFacade.cs
+++ b/template/netwrix-csharp/ConnectorFramework/AACorePlatformFacade.cs
@@ -51,7 +51,18 @@ public sealed class AACorePlatformFacade : ICorePlatformFacade, IDisposable
 
             if (isFinal)
             {
-                await _writer.FlushTablesAsync(CancellationToken.None);
+                // Non-closing buffer flush: pushes this worker's partial batch to ClickHouse
+                // immediately without closing the BatchManager channels. Required for incremental
+                // data visibility on long-running scans (hours/days/weeks).
+                //
+                // We deliberately do NOT call FlushTablesAsync (which closes channels) because
+                // CrawlRunOrchestrator runs N concurrent workers: each passes isFinal=true when
+                // its own task finishes, while other workers are still running. Closing channels
+                // here would corrupt writes from workers still queued behind _writeLock.
+                //
+                // The single closing flush is Handler.RunScanAsync after orchestrator.RunAsync():
+                //   await ctx.FlushTablesAsync(CancellationToken.None);
+                _writer.FlushBuffers(CancellationToken.None);
             }
         }
         finally

--- a/template/netwrix-csharp/ConnectorFramework/BatchManager.cs
+++ b/template/netwrix-csharp/ConnectorFramework/BatchManager.cs
@@ -81,7 +81,9 @@ public sealed class BatchManager : IAsyncDisposable
                 // AddObject has no ct — batches auto-enqueued mid-scan use None.
                 if (!_flushChannel.Writer.TryWrite((snapshot.Data, snapshot.Count, CancellationToken.None)))
                 {
-                    _logger.LogError("Failed to enqueue batch for table {Table} — channel is closed", _tableName);
+                    throw new InvalidOperationException(
+                        $"Batch enqueue failed for table '{_tableName}' — channel is closed. " +
+                        "AddObject() must not be called after FlushAsync().");
                 }
 
                 _buffer = NewBuffer();
@@ -102,10 +104,11 @@ public sealed class BatchManager : IAsyncDisposable
     }
 
     /// <summary>
-    /// Flushes remaining buffered objects and waits for the background worker to drain.
-    /// Call this once at the end of a scan before the handler returns.
+    /// Drains any buffered objects into the flush channel without closing it or awaiting the
+    /// background worker. Safe to call while other workers will continue writing after this.
+    /// Unlike <see cref="FlushAsync"/>, does NOT signal channel completion.
     /// </summary>
-    public async Task FlushAsync(CancellationToken ct = default)
+    public void FlushBuffer(CancellationToken ct = default)
     {
         if (_buffer.Length > 1)
         {
@@ -113,13 +116,23 @@ public sealed class BatchManager : IAsyncDisposable
             // Propagate ct so the _onFlushed callback (progress reporting) respects cancellation.
             if (!_flushChannel.Writer.TryWrite((snapshot.Data, snapshot.Count, ct)))
             {
-                _logger.LogError("Failed to enqueue final batch for table {Table} — channel is closed", _tableName);
+                throw new InvalidOperationException(
+                    $"Batch enqueue failed for table '{_tableName}' — channel is closed. " +
+                    "FlushBuffer() must not be called after FlushAsync().");
             }
 
             _buffer = NewBuffer();
             _pendingObjectCount = 0;
         }
+    }
 
+    /// <summary>
+    /// Flushes remaining buffered objects and waits for the background worker to drain.
+    /// Call this once at the end of a scan before the handler returns.
+    /// </summary>
+    public async Task FlushAsync(CancellationToken ct = default)
+    {
+        FlushBuffer(ct);
         _flushChannel.Writer.TryComplete();
         await _flushWorker;
     }

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorStateClient.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorStateClient.cs
@@ -1,0 +1,245 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using Netwrix.Overlord.Sdk.Core.Storage.Exceptions;
+
+namespace Netwrix.ConnectorFramework;
+
+/// <summary>
+/// Typed HTTP client for the connector-state service. Owns all transport concerns:
+/// base URL (set via DI registration), constant default headers (Function-Type),
+/// per-request headers (Scan-Id, Scan-Execution-Id, traceparent), error wrapping,
+/// and correct cancellation propagation.
+/// </summary>
+public sealed class ConnectorStateClient
+{
+    /// <summary>Named client key used in both DI registration and singleton factory creation.</summary>
+    public const string HttpClientName = "connector-state";
+
+    // Maximum query-string length for a single DELETE request. Each key becomes a &name=
+    // query parameter; splitting into batches prevents UriFormatException (.NET URI limit
+    // is ~65,519 chars) and respects typical proxy/nginx URL size limits (~8 KB).
+    internal const int MaxDeleteQueryLength = 4_000;
+
+    private readonly HttpClient _client;
+    private readonly ILogger<ConnectorStateClient> _logger;
+
+    public ConnectorStateClient(HttpClient client, ILogger<ConnectorStateClient> logger)
+    {
+        _client = client;
+        _logger = logger;
+    }
+
+    // ── Public methods ───────────────────────────────────────────────────────
+
+    public async Task<Dictionary<string, string>> GetStateAsync(
+        string scanId, string? scanExecutionId, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"?scanId={Uri.EscapeDataString(scanId)}");
+        AddPerRequestHeaders(request, scanId, scanExecutionId);
+
+        try
+        {
+            using var response = await _client.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new StateStorageException(
+                    $"connector-state GET returned {(int)response.StatusCode}");
+            }
+
+            var body = await response.Content.ReadAsStringAsync(ct);
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+
+            if (!root.TryGetProperty("success", out var successProp) || !successProp.GetBoolean())
+            {
+                var error = root.TryGetProperty("error", out var errProp)
+                    ? errProp.GetString() : "Unknown error";
+                throw new StateStorageException($"connector-state GET failed: {error}");
+            }
+
+            if (root.TryGetProperty("data", out var dataProp))
+            {
+                return dataProp.Deserialize<Dictionary<string, string>>()
+                       ?? new Dictionary<string, string>();
+            }
+
+            return new Dictionary<string, string>();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (StateStorageException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "connector-state GET failed for scan {ScanId}", scanId);
+            throw new StateStorageException($"connector-state GET failed for scan {scanId}", ex);
+        }
+    }
+
+    public async Task PostStateAsync(
+        string scanId, string? scanExecutionId, Dictionary<string, string> data, CancellationToken ct)
+    {
+        var payload = new { scanId, data };
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/")
+        {
+            Content = new StringContent(
+                JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json"),
+        };
+        AddPerRequestHeaders(request, scanId, scanExecutionId);
+
+        try
+        {
+            using var response = await _client.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new StateStorageException(
+                    $"connector-state POST returned {(int)response.StatusCode}");
+            }
+
+            var body = await response.Content.ReadAsStringAsync(ct);
+            if (!string.IsNullOrWhiteSpace(body))
+            {
+                using var doc = JsonDocument.Parse(body);
+                var root = doc.RootElement;
+                if (root.TryGetProperty("success", out var successProp) && !successProp.GetBoolean())
+                {
+                    var error = root.TryGetProperty("error", out var errProp)
+                        ? errProp.GetString() : "Unknown error";
+                    throw new StateStorageException($"connector-state POST failed: {error}");
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (StateStorageException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "connector-state POST failed for scan {ScanId}", scanId);
+            throw new StateStorageException($"connector-state POST failed for scan {scanId}", ex);
+        }
+    }
+
+    /// <summary>
+    /// Deletes all <paramref name="names"/> from the connector-state service, automatically
+    /// splitting into URL-length-bounded batches to avoid <see cref="UriFormatException"/>
+    /// when key count or key length would produce a query string exceeding
+    /// <see cref="MaxDeleteQueryLength"/> characters.
+    /// </summary>
+    public async Task DeleteManyAsync(
+        string scanId, string? scanExecutionId, string[] names, CancellationToken ct)
+    {
+        var baseQs = $"?scanId={Uri.EscapeDataString(scanId)}";
+        var sb = new StringBuilder();
+
+        var i = 0;
+        while (i < names.Length)
+        {
+            sb.Clear();
+            sb.Append(baseQs);
+            var batchStart = i;
+
+            while (i < names.Length)
+            {
+                var escaped = $"&name={Uri.EscapeDataString(names[i])}";
+                // If adding this key would exceed the limit AND we already have at least one key
+                // in the batch, flush now. A single key that is longer than the limit is sent
+                // alone (can't split further).
+                if (sb.Length + escaped.Length > MaxDeleteQueryLength && i > batchStart)
+                {
+                    break;
+                }
+
+                sb.Append(escaped);
+                i++;
+            }
+
+            _logger.LogDebug(
+                "Deleting state keys {Start}–{End} of {Total} for scan {ScanId}",
+                batchStart, i - 1, names.Length, scanId);
+
+            await SendDeleteAsync(scanId, scanExecutionId, sb.ToString(), ct);
+        }
+    }
+
+    // ── Private HTTP helpers ─────────────────────────────────────────────────
+
+    private async Task SendDeleteAsync(
+        string scanId, string? scanExecutionId, string queryString, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Delete, queryString);
+        AddPerRequestHeaders(request, scanId, scanExecutionId);
+
+        try
+        {
+            using var response = await _client.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new StateStorageException(
+                    $"connector-state DELETE returned {(int)response.StatusCode}");
+            }
+
+            var body = await response.Content.ReadAsStringAsync(ct);
+            if (!string.IsNullOrWhiteSpace(body))
+            {
+                using var doc = JsonDocument.Parse(body);
+                var root = doc.RootElement;
+                if (root.TryGetProperty("success", out var successProp) && !successProp.GetBoolean())
+                {
+                    var error = root.TryGetProperty("error", out var errProp)
+                        ? errProp.GetString() : "Unknown error";
+                    throw new StateStorageException($"connector-state DELETE failed: {error}");
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (StateStorageException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "connector-state DELETE failed for scan {ScanId}", scanId);
+            throw new StateStorageException($"connector-state DELETE failed for scan {scanId}", ex);
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static void AddPerRequestHeaders(
+        HttpRequestMessage request, string scanId, string? scanExecutionId)
+    {
+        request.Headers.TryAddWithoutValidation("Scan-Id", scanId);
+        if (scanExecutionId is not null)
+        {
+            request.Headers.TryAddWithoutValidation("Scan-Execution-Id", scanExecutionId);
+        }
+
+        // Function-Type is a default header set at DI registration time — not added here.
+
+        var activity = Activity.Current;
+        if (activity?.Id is not null)
+        {
+            request.Headers.TryAddWithoutValidation("traceparent", activity.Id);
+        }
+
+        if (!string.IsNullOrEmpty(activity?.TraceStateString))
+        {
+            request.Headers.TryAddWithoutValidation("tracestate", activity.TraceStateString);
+        }
+    }
+}

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorStateStorage.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorStateStorage.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Netwrix.Overlord.Sdk.Core.Storage;
@@ -14,7 +13,7 @@ public sealed class ConnectorStateStorage : IStateStorage
 
     private readonly string? _scanId;
     private readonly string? _scanExecutionId;
-    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ConnectorStateClient _stateClient;
     private readonly ILogger<ConnectorStateStorage> _logger;
 
     /// <summary>
@@ -22,29 +21,28 @@ public sealed class ConnectorStateStorage : IStateStorage
     /// </summary>
     public ConnectorStateStorage(
         ConnectorRequestData request,
-        IHttpClientFactory httpClientFactory,
+        ConnectorStateClient stateClient,
         ILogger<ConnectorStateStorage> logger)
-        : this(request.Execution.ScanId, request.Execution.ScanExecutionId, httpClientFactory, logger)
+        : this(request.Execution.ScanId, request.Execution.ScanExecutionId, stateClient, logger)
     {
     }
 
     /// <summary>
     /// Factory constructor — used by <see cref="ConnectorRunStateStorageFactory"/> to create
     /// instances without requiring a live request scope (e.g. inside the singleton orchestrator).
+    /// Must remain <c>public</c>: connector assemblies are not listed in InternalsVisibleTo.
     /// </summary>
     public ConnectorStateStorage(
         string? scanId,
         string? scanExecutionId,
-        IHttpClientFactory httpClientFactory,
+        ConnectorStateClient stateClient,
         ILogger<ConnectorStateStorage> logger)
     {
         _scanId = scanId;
         _scanExecutionId = scanExecutionId;
-        _httpClientFactory = httpClientFactory;
+        _stateClient = stateClient;
         _logger = logger;
     }
-
-    private string? ScanId => _scanId;
 
     // ── IStateStorage ────────────────────────────────────────────────────────
 
@@ -52,7 +50,7 @@ public sealed class ConnectorStateStorage : IStateStorage
     {
         ArgumentException.ThrowIfNullOrEmpty(key);
 
-        if (ScanId is null)
+        if (_scanId is null)
         {
             _logger.LogWarning("TryGetAsync called but ScanId is null — returning NotFound");
             return TryGetResult<T>.NotFound;
@@ -75,7 +73,7 @@ public sealed class ConnectorStateStorage : IStateStorage
         ArgumentException.ThrowIfNullOrEmpty(key);
         ArgumentNullException.ThrowIfNull(value);
 
-        if (ScanId is null)
+        if (_scanId is null)
         {
             _logger.LogWarning("SetAsync called but ScanId is null — skipping");
             return;
@@ -91,11 +89,14 @@ public sealed class ConnectorStateStorage : IStateStorage
         ArgumentException.ThrowIfNullOrEmpty(key);
         ArgumentNullException.ThrowIfNull(value);
 
-        if (ScanId is null)
+        if (_scanId is null)
         {
             throw new StateStorageException($"SetIfMatchAsync called but ScanId is null — cannot write state for key: {key}");
         }
 
+        // The connector-state service does not support optimistic concurrency (ETags).
+        // expectedETag is intentionally ignored; the write is always unconditional.
+        // Return string.Empty to signal "no ETag" per the IStateStorage contract.
         var json = Serialize(key, value);
         await WriteStateAsync(new Dictionary<string, string> { [key] = json }, cancellationToken);
         return string.Empty;
@@ -105,7 +106,7 @@ public sealed class ConnectorStateStorage : IStateStorage
     {
         ArgumentException.ThrowIfNullOrEmpty(key);
 
-        if (ScanId is null)
+        if (_scanId is null)
         {
             _logger.LogWarning("DeleteAsync called but ScanId is null — skipping");
             return false;
@@ -119,7 +120,7 @@ public sealed class ConnectorStateStorage : IStateStorage
     {
         ArgumentNullException.ThrowIfNull(keyPrefix);
 
-        if (ScanId is null)
+        if (_scanId is null)
         {
             _logger.LogWarning("DeleteAllAsync called but ScanId is null — skipping");
             return;
@@ -160,7 +161,7 @@ public sealed class ConnectorStateStorage : IStateStorage
         string keyPrefix,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        if (ScanId is null)
+        if (_scanId is null)
         {
             _logger.LogWarning("ListAllKeysAsync called but ScanId is null — returning empty");
             yield break;
@@ -197,141 +198,14 @@ public sealed class ConnectorStateStorage : IStateStorage
 
     // ── HTTP helpers ─────────────────────────────────────────────────────────
 
-    private async Task<Dictionary<string, string>> FetchAllStateAsync(CancellationToken ct)
-    {
-        var serviceUrl = ServiceUrlHelper.Resolve("CONNECTOR_STATE_FUNCTION", "connector-state");
-        var url = $"{serviceUrl}?scanId={Uri.EscapeDataString(ScanId!)}";
+    private Task<Dictionary<string, string>> FetchAllStateAsync(CancellationToken ct)
+        => _stateClient.GetStateAsync(_scanId!, _scanExecutionId, ct);
 
-        try
-        {
-            using var client = _httpClientFactory.CreateClient("connector-state");
-            using var request = new HttpRequestMessage(HttpMethod.Get, url);
-            foreach (var (k, v) in BuildCallerHeaders())
-            {
-                request.Headers.TryAddWithoutValidation(k, v);
-            }
+    private Task WriteStateAsync(Dictionary<string, string> data, CancellationToken ct)
+        => _stateClient.PostStateAsync(_scanId!, _scanExecutionId, data, ct);
 
-            using var response = await client.SendAsync(request, ct);
-            if (!response.IsSuccessStatusCode)
-            {
-                throw new StateStorageException($"connector-state GET returned {(int)response.StatusCode}");
-            }
-
-            var body = await response.Content.ReadAsStringAsync(ct);
-            using var doc = JsonDocument.Parse(body);
-            var root = doc.RootElement;
-
-            if (!root.TryGetProperty("success", out var successProp) || !successProp.GetBoolean())
-            {
-                var error = root.TryGetProperty("error", out var errProp) ? errProp.GetString() : "Unknown error";
-                throw new StateStorageException($"connector-state GET failed: {error}");
-            }
-
-            if (root.TryGetProperty("data", out var dataProp))
-            {
-                return dataProp.Deserialize<Dictionary<string, string>>() ?? new Dictionary<string, string>();
-            }
-
-            return new Dictionary<string, string>();
-        }
-        catch (StateStorageException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            throw new StateStorageException($"connector-state GET failed for scan {ScanId}", ex);
-        }
-    }
-
-    private async Task WriteStateAsync(Dictionary<string, string> data, CancellationToken ct)
-    {
-        var serviceUrl = ServiceUrlHelper.Resolve("CONNECTOR_STATE_FUNCTION", "connector-state");
-        var payload = new { scanId = ScanId, data };
-
-        try
-        {
-            using var client = _httpClientFactory.CreateClient("connector-state");
-            using var request = new HttpRequestMessage(HttpMethod.Post, serviceUrl)
-            {
-                Content = new StringContent(JsonSerializer.Serialize(payload), System.Text.Encoding.UTF8, "application/json"),
-            };
-            foreach (var (k, v) in BuildCallerHeaders())
-            {
-                request.Headers.TryAddWithoutValidation(k, v);
-            }
-
-            using var response = await client.SendAsync(request, ct);
-            if (!response.IsSuccessStatusCode)
-            {
-                throw new StateStorageException($"connector-state POST returned {(int)response.StatusCode}");
-            }
-
-            var body = await response.Content.ReadAsStringAsync(ct);
-            if (!string.IsNullOrWhiteSpace(body))
-            {
-                using var doc = JsonDocument.Parse(body);
-                var root = doc.RootElement;
-                if (root.TryGetProperty("success", out var successProp) && !successProp.GetBoolean())
-                {
-                    var error = root.TryGetProperty("error", out var errProp) ? errProp.GetString() : "Unknown error";
-                    throw new StateStorageException($"connector-state POST failed: {error}");
-                }
-            }
-        }
-        catch (StateStorageException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            throw new StateStorageException($"connector-state POST failed for scan {ScanId}", ex);
-        }
-    }
-
-    private async Task DeleteStateAsync(string[] names, CancellationToken ct)
-    {
-        var serviceUrl = ServiceUrlHelper.Resolve("CONNECTOR_STATE_FUNCTION", "connector-state");
-        var qs = $"?scanId={Uri.EscapeDataString(ScanId!)}";
-        qs += string.Concat(names.Select(n => $"&name={Uri.EscapeDataString(n)}"));
-        var url = serviceUrl + qs;
-
-        try
-        {
-            using var client = _httpClientFactory.CreateClient("connector-state");
-            using var request = new HttpRequestMessage(HttpMethod.Delete, url);
-            foreach (var (k, v) in BuildCallerHeaders())
-            {
-                request.Headers.TryAddWithoutValidation(k, v);
-            }
-
-            using var response = await client.SendAsync(request, ct);
-            if (!response.IsSuccessStatusCode)
-            {
-                throw new StateStorageException($"connector-state DELETE returned {(int)response.StatusCode}");
-            }
-
-            var body = await response.Content.ReadAsStringAsync(ct);
-            if (!string.IsNullOrWhiteSpace(body))
-            {
-                using var doc = JsonDocument.Parse(body);
-                var root = doc.RootElement;
-                if (root.TryGetProperty("success", out var successProp) && !successProp.GetBoolean())
-                {
-                    var error = root.TryGetProperty("error", out var errProp) ? errProp.GetString() : "Unknown error";
-                    throw new StateStorageException($"connector-state DELETE failed: {error}");
-                }
-            }
-        }
-        catch (StateStorageException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            throw new StateStorageException($"connector-state DELETE failed for scan {ScanId}", ex);
-        }
-    }
+    private Task DeleteStateAsync(string[] names, CancellationToken ct)
+        => _stateClient.DeleteManyAsync(_scanId!, _scanExecutionId, names, ct);
 
     // ── Serialization ────────────────────────────────────────────────────────
 
@@ -370,39 +244,6 @@ public sealed class ConnectorStateStorage : IStateStorage
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────
-
-    private Dictionary<string, string> BuildCallerHeaders()
-    {
-        var headers = new Dictionary<string, string>();
-
-        if (_scanId is not null)
-        {
-            headers["Scan-Id"] = _scanId;
-        }
-
-        if (_scanExecutionId is not null)
-        {
-            headers["Scan-Execution-Id"] = _scanExecutionId;
-        }
-
-        headers["Function-Type"] = Environment.GetEnvironmentVariable("FUNCTION_TYPE") ?? "netwrix";
-
-        var current = Activity.Current;
-        if (current is not null)
-        {
-            if (current.Id is not null)
-            {
-                headers["traceparent"] = current.Id;
-            }
-
-            if (!string.IsNullOrEmpty(current.TraceStateString))
-            {
-                headers["tracestate"] = current.TraceStateString;
-            }
-        }
-
-        return headers;
-    }
 
     private static bool MatchesPrefix(string key, string prefix)
     {

--- a/template/netwrix-csharp/ConnectorFramework/FunctionContext.cs
+++ b/template/netwrix-csharp/ConnectorFramework/FunctionContext.cs
@@ -139,6 +139,15 @@ public sealed class FunctionContext : IScanWriter, IScanProgress, IAsyncDisposab
     public void SaveObject(string table, object obj, bool updateStatus = true)
         => GetTable(table).AddObject(obj, updateStatus);
 
+    /// <inheritdoc/>
+    public void FlushBuffers(CancellationToken ct = default)
+    {
+        foreach (var (_, bm) in _tables)
+        {
+            bm.FlushBuffer(ct);
+        }
+    }
+
     /// <summary>
     /// Flushes all active table batch managers. The framework calls this automatically
     /// after a job-mode invocation completes.

--- a/template/netwrix-csharp/ConnectorFramework/IScanWriter.cs
+++ b/template/netwrix-csharp/ConnectorFramework/IScanWriter.cs
@@ -8,5 +8,12 @@ namespace Netwrix.ConnectorFramework;
 public interface IScanWriter
 {
     void SaveObject(string tableName, object obj, bool updateStatus = true);
+
+    /// <summary>
+    /// Drains in-memory buffers for all tables to the flush channel without closing channels.
+    /// Safe to call from concurrent workers — does not complete BatchManagers.
+    /// </summary>
+    void FlushBuffers(CancellationToken ct = default);
+
     Task FlushTablesAsync(CancellationToken ct = default);
 }

--- a/template/netwrix-csharp/ConnectorFramework/Program.cs
+++ b/template/netwrix-csharp/ConnectorFramework/Program.cs
@@ -198,9 +198,13 @@ internal static class Program
                     new KeyValuePair<string, object?>("status", metricStatus));
 
                 if (exitCode == 0)
+                {
                     jobActivity?.SetStatus(ActivityStatusCode.Ok);
+                }
                 else
+                {
                     jobActivity?.SetStatus(ActivityStatusCode.Error, "Handler returned error statusCode");
+                }
             }
         }
         catch (Exception ex)
@@ -284,6 +288,14 @@ internal static class Program
         // RedisSignalHandler accepts IConnectionMultiplexer? and degrades gracefully.
 
         services.AddHttpClient();
+        services.AddHttpClient<ConnectorStateClient>(ConnectorStateClient.HttpClientName, client =>
+        {
+            var url = ServiceUrlHelper.Resolve("CONNECTOR_STATE_FUNCTION", "connector-state");
+            client.BaseAddress = new Uri(url.TrimEnd('/') + "/");
+            client.DefaultRequestHeaders.TryAddWithoutValidation(
+                "Function-Type",
+                Environment.GetEnvironmentVariable("FUNCTION_TYPE") ?? "netwrix");
+        });
         // Apply rate-limit tracking to every named HttpClient (including connector-developer clients).
         services.ConfigureAll<HttpClientFactoryOptions>(options =>
             options.HttpMessageHandlerBuilderActions.Add(

--- a/template/netwrix-csharp/ConnectorFramework/Program.cs
+++ b/template/netwrix-csharp/ConnectorFramework/Program.cs
@@ -157,6 +157,9 @@ internal static class Program
             var handlerInstance = scope.ServiceProvider.GetRequiredService<IConnectorHandler>();
             var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
 
+            lifetime.ApplicationStopping.Register(() =>
+                logger.LogWarning("SIGTERM received — ApplicationStopping triggered; job will be cancelled"));
+
             isLongRunning = requestData.Execution.IsLongRunning;
 
             using (logger.BeginScope(new Dictionary<string, object?>


### PR DESCRIPTION
## Summary

- **AB#432093** — Replace premature channel-closing `FlushTablesAsync` call with new non-closing `BatchManager.FlushBuffer()` to prevent silent data loss when multiple concurrent workers share a single `AACorePlatformFacade` instance. The final `FlushTablesAsync` (which closes channels) is now called only by `Handler.RunScanAsync` after all workers have finished. Also converts silent `TryWrite` failures on closed channels to hard throws.
- **AB#432113** — Introduce `ConnectorStateClient` typed HTTP client that batches DELETE requests into URL-length-bounded chunks (4,000 chars max), preventing `UriFormatException` when deleting large numbers of keys. Refactors `ConnectorStateStorage` to delegate all HTTP transport to the new client.

## Test plan

- [ ] `ConnectorStateStorageTests` — verify batched DELETE behaviour and URL-length boundary cases
- [ ] `AACorePlatformFacadeTests` — verify `FlushBuffer` does not close channels; concurrent-worker scenario covered
- [ ] `CrawlRunOrchestratorPauseResumeTests` — verify no regression in pause/resume path
- [ ] Run full test suite: `dotnet test`
- [ ] Confirm no build warnings: `dotnet build`

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>