### PR TITLE
feat(templates): stream connector-state HTTP responses and add per-key lookup

### DIFF
--- a/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateStorageTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateStorageTests.cs
@@ -468,4 +468,86 @@ public class ConnectorStateStorageTests
         Assert.Equal(new[] { "src/tenant/bookmark" }, depth1.ToArray());
         Assert.Equal(new[] { "src/tenant/other/bookmark", "src/tenant/site/bookmark", "src/tenant/site/cursor" }, depth2.ToArray());
     }
+
+    // ── TryGetAsync per-key path ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task TryGetAsync_IssuesExactlyOneHttpCall()
+    {
+        var stateData = new Dictionary<string, string> { ["k"] = "\"v\"" };
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>((_, _) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(StateResponse(stateData), Encoding.UTF8, "application/json"),
+                }));
+        var storage = CreateStorage(CreateClient(handlerMock.Object));
+
+        await storage.TryGetAsync<string>("k");
+
+        handlerMock.Protected().Verify(
+            "SendAsync", Times.Once(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TryGetAsync_AndDeleteAllAsync_IssueIndependentGets()
+    {
+        var stateData = new Dictionary<string, string>
+        {
+            ["prefix/a"] = "\"v\"",
+            ["prefix/b"] = "\"v\"",
+        };
+        var getCount = 0;
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>((req, _) =>
+            {
+                if (req.Method == HttpMethod.Get)
+                {
+                    getCount++;
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(StateResponse(stateData), Encoding.UTF8, "application/json"),
+                });
+            });
+        var storage = CreateStorage(CreateClient(handlerMock.Object));
+
+        await storage.TryGetAsync<string>("prefix/a");
+        await storage.DeleteAllAsync("prefix");
+
+        Assert.Equal(2, getCount);
+    }
+
+    // ── GetStateValueAsync ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetStateValueAsync_ReturnsNull_WhenKeyAbsent()
+    {
+        var stateData = new Dictionary<string, string> { ["other"] = "\"v\"" };
+        var client = CreateClient(StateResponse(stateData));
+
+        var result = await client.GetStateValueAsync("scan-id", null, "missing", CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetStateValueAsync_ThrowsStorageException_OnHttpError()
+    {
+        var client = CreateClient("{}", HttpStatusCode.InternalServerError);
+
+        await Assert.ThrowsAsync<StateStorageException>(
+            () => client.GetStateValueAsync("scan-id", null, "key", CancellationToken.None));
+    }
 }

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorStateClient.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorStateClient.cs
@@ -42,15 +42,15 @@ public sealed class ConnectorStateClient
 
         try
         {
-            using var response = await _client.SendAsync(request, ct);
+            using var response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
             if (!response.IsSuccessStatusCode)
             {
                 throw new StateStorageException(
                     $"connector-state GET returned {(int)response.StatusCode}");
             }
 
-            var body = await response.Content.ReadAsStringAsync(ct);
-            using var doc = JsonDocument.Parse(body);
+            await using var stream = await response.Content.ReadAsStreamAsync(ct);
+            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct);
             var root = doc.RootElement;
 
             if (!root.TryGetProperty("success", out var successProp) || !successProp.GetBoolean())
@@ -67,6 +67,57 @@ public sealed class ConnectorStateClient
             }
 
             return new Dictionary<string, string>();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (StateStorageException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "connector-state GET failed for scan {ScanId}", scanId);
+            throw new StateStorageException($"connector-state GET failed for scan {scanId}", ex);
+        }
+    }
+
+    public async Task<string?> GetStateValueAsync(
+        string scanId, string? scanExecutionId, string key, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"?scanId={Uri.EscapeDataString(scanId)}");
+        AddPerRequestHeaders(request, scanId, scanExecutionId);
+
+        try
+        {
+            using var response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new StateStorageException(
+                    $"connector-state GET returned {(int)response.StatusCode}");
+            }
+
+            await using var stream = await response.Content.ReadAsStreamAsync(ct);
+            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct);
+            var root = doc.RootElement;
+
+            if (!root.TryGetProperty("success", out var successProp) || !successProp.GetBoolean())
+            {
+                var error = root.TryGetProperty("error", out var errProp)
+                    ? errProp.GetString() : "Unknown error";
+                throw new StateStorageException($"connector-state GET failed: {error}");
+            }
+
+            if (root.TryGetProperty("data", out var dataProp) &&
+                dataProp.TryGetProperty(key, out var valueProp))
+            {
+                return valueProp.GetString();
+            }
+
+            return null;
         }
         catch (OperationCanceledException)
         {

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorStateClient.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorStateClient.cs
@@ -35,56 +35,32 @@ public sealed class ConnectorStateClient
     public async Task<Dictionary<string, string>> GetStateAsync(
         string scanId, string? scanExecutionId, CancellationToken ct)
     {
-        using var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"?scanId={Uri.EscapeDataString(scanId)}");
-        AddPerRequestHeaders(request, scanId, scanExecutionId);
-
-        try
+        using var doc = await OpenStateDocumentAsync(scanId, scanExecutionId, ct);
+        var root = doc.RootElement;
+        if (root.TryGetProperty("data", out var dataProp))
         {
-            using var response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
-            if (!response.IsSuccessStatusCode)
-            {
-                throw new StateStorageException(
-                    $"connector-state GET returned {(int)response.StatusCode}");
-            }
-
-            await using var stream = await response.Content.ReadAsStreamAsync(ct);
-            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct);
-            var root = doc.RootElement;
-
-            if (!root.TryGetProperty("success", out var successProp) || !successProp.GetBoolean())
-            {
-                var error = root.TryGetProperty("error", out var errProp)
-                    ? errProp.GetString() : "Unknown error";
-                throw new StateStorageException($"connector-state GET failed: {error}");
-            }
-
-            if (root.TryGetProperty("data", out var dataProp))
-            {
-                return dataProp.Deserialize<Dictionary<string, string>>()
-                       ?? new Dictionary<string, string>();
-            }
-
-            return new Dictionary<string, string>();
+            return dataProp.Deserialize<Dictionary<string, string>>() ?? new Dictionary<string, string>();
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (StateStorageException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "connector-state GET failed for scan {ScanId}", scanId);
-            throw new StateStorageException($"connector-state GET failed for scan {scanId}", ex);
-        }
+
+        return new Dictionary<string, string>();
     }
 
     public async Task<string?> GetStateValueAsync(
         string scanId, string? scanExecutionId, string key, CancellationToken ct)
+    {
+        using var doc = await OpenStateDocumentAsync(scanId, scanExecutionId, ct);
+        var root = doc.RootElement;
+        if (root.TryGetProperty("data", out var dataProp) &&
+            dataProp.TryGetProperty(key, out var valueProp))
+        {
+            return valueProp.GetString();
+        }
+
+        return null;
+    }
+
+    private async Task<JsonDocument> OpenStateDocumentAsync(
+        string scanId, string? scanExecutionId, CancellationToken ct)
     {
         using var request = new HttpRequestMessage(
             HttpMethod.Get,
@@ -101,23 +77,18 @@ public sealed class ConnectorStateClient
             }
 
             await using var stream = await response.Content.ReadAsStreamAsync(ct);
-            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct);
+            var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct);
             var root = doc.RootElement;
 
             if (!root.TryGetProperty("success", out var successProp) || !successProp.GetBoolean())
             {
+                doc.Dispose();
                 var error = root.TryGetProperty("error", out var errProp)
                     ? errProp.GetString() : "Unknown error";
                 throw new StateStorageException($"connector-state GET failed: {error}");
             }
 
-            if (root.TryGetProperty("data", out var dataProp) &&
-                dataProp.TryGetProperty(key, out var valueProp))
-            {
-                return valueProp.GetString();
-            }
-
-            return null;
+            return doc;
         }
         catch (OperationCanceledException)
         {

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorStateStorage.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorStateStorage.cs
@@ -56,9 +56,9 @@ public sealed class ConnectorStateStorage : IStateStorage
             return TryGetResult<T>.NotFound;
         }
 
-        var allState = await FetchAllStateAsync(cancellationToken);
+        var json = await _stateClient.GetStateValueAsync(_scanId, _scanExecutionId, key, cancellationToken);
 
-        if (!allState.TryGetValue(key, out var json))
+        if (json is null)
         {
             return TryGetResult<T>.NotFound;
         }


### PR DESCRIPTION
## Summary

- `GetStateAsync` now uses `HttpCompletionOption.ResponseHeadersRead` + `JsonDocument.ParseAsync(stream)`, eliminating the intermediate string allocation when reading the full state dictionary
- New `GetStateValueAsync` method extracts a single key's value by navigating the parsed document via `TryGetProperty`, avoiding materialisation of `Dictionary<string, string>` for single-key reads
- `ConnectorStateStorage.TryGetAsync<T>` delegates to `GetStateValueAsync` instead of fetching and materialising the full state dictionary
- 4 new tests covering the per-key path and error handling

## Test plan

- [x] All 158 existing tests pass — `dotnet test ConnectorFramework.Tests/ConnectorFramework.Tests.csproj`
- [x] Zero build warnings — `dotnet build ConnectorFramework/ConnectorFramework.csproj`
- [x] New tests: `TryGetAsync_IssuesExactlyOneHttpCall`, `TryGetAsync_AndDeleteAllAsync_IssueIndependentGets`, `GetStateValueAsync_ReturnsNull_WhenKeyAbsent`, `GetStateValueAsync_ThrowsStorageException_OnHttpError`

AB#433348

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>