### PR TITLE
AB#433406 — Remove dead _crawlTaskQueue from AACrawlTaskCorePlatformFacade

### DIFF
--- a/template/netwrix-csharp/ConnectorFramework/AACrawlTaskCorePlatformFacade.cs
+++ b/template/netwrix-csharp/ConnectorFramework/AACrawlTaskCorePlatformFacade.cs
@@ -18,7 +18,6 @@ public sealed class AACrawlTaskCorePlatformFacade : ICorePlatformFacade, ICrawlT
     private readonly IScanProgress _progress;
     private readonly ILogger<AACrawlTaskCorePlatformFacade> _logger;
 
-    private readonly ConcurrentQueue<ApiChildCrawlTask> _crawlTaskQueue = new();
     private readonly ConcurrentDictionary<Guid, int> _processedItems = new();
     private readonly ConcurrentDictionary<Guid, int> _processedErrors = new();
     private readonly ConcurrentDictionary<Guid, long> _taskStartTimestamps = new();
@@ -65,12 +64,6 @@ public sealed class AACrawlTaskCorePlatformFacade : ICorePlatformFacade, ICrawlT
         => _core.UploadActivityRecords(activityRecords);
 
     // ── ICrawlTaskManagementPlatformFacade ────────────────────────────────────
-
-    /// <summary>
-    /// Exposes the queue of child crawl tasks enqueued during <see cref="FinaliseTask"/>.
-    /// Drain this queue after the scan loop completes to schedule sub-tasks.
-    /// </summary>
-    public ConcurrentQueue<ApiChildCrawlTask> CrawlTaskQueue => _crawlTaskQueue;
 
     /// <summary>
     /// Stores the request payloads deserialized from the connector request body.
@@ -166,20 +159,6 @@ public sealed class AACrawlTaskCorePlatformFacade : ICorePlatformFacade, ICrawlT
             ConnectorMetrics.TaskDuration.Record(Stopwatch.GetElapsedTime(startTimestamp).TotalSeconds);
         }
         ConnectorMetrics.TasksCompleted.Add(1);
-
-        if (taskProgress.ChildTasks is null)
-        {
-            _logger.LogDebug(
-                "FinaliseTask: leaf task {CrawlTaskReference} completed — no children to enqueue",
-                taskProgress.CrawlTaskReference);
-        }
-        else
-        {
-            foreach (var childTask in taskProgress.ChildTasks)
-            {
-                _crawlTaskQueue.Enqueue(childTask);
-            }
-        }
 
         // Remove the finalized task's entries to prevent unbounded memory growth
         // on long-running connectors with many child tasks.

--- a/template/netwrix-csharp/function/Handler.cs
+++ b/template/netwrix-csharp/function/Handler.cs
@@ -27,8 +27,7 @@ public class Handler : IConnectorHandler
     ///
     /// All four interface aliases resolve to the same scoped instance of
     /// <see cref="AACrawlTaskCorePlatformFacade"/>, preventing the split-state bug where
-    /// count dictionaries
-    /// diverge across different interface resolutions.
+    /// count dictionaries diverge across different interface resolutions.
     ///
     /// TODO: add connector-specific services after this block (e.g. SharePoint graph client, options).
     /// </summary>

--- a/template/netwrix-csharp/function/Handler.cs
+++ b/template/netwrix-csharp/function/Handler.cs
@@ -27,7 +27,7 @@ public class Handler : IConnectorHandler
     ///
     /// All four interface aliases resolve to the same scoped instance of
     /// <see cref="AACrawlTaskCorePlatformFacade"/>, preventing the split-state bug where
-    /// <see cref="AACrawlTaskCorePlatformFacade.CrawlTaskQueue"/> or count dictionaries
+    /// count dictionaries
     /// diverge across different interface resolutions.
     ///
     /// TODO: add connector-specific services after this block (e.g. SharePoint graph client, options).


### PR DESCRIPTION
## Summary

- Removes `_crawlTaskQueue` (`ConcurrentQueue<ApiChildCrawlTask>`), the `CrawlTaskQueue` property, and the child-enqueue loop in `FinaliseTask` from `AACrawlTaskCorePlatformFacade`
- Removes the stale `CrawlTaskQueue` `<see cref>` reference from the `MapServices` doc comment in `Handler.cs`
- `CrawlRunOrchestrationFacade` now intercepts `FinaliseTask` and pushes child tasks directly onto the orchestrator's internal `CrawlTaskWorkQueue`; the old queue was written during `FinaliseTask` but never read by anything

AB#433406

## Test plan

- [x] `dotnet build` passes with zero errors and zero warnings
- [x] `dotnet test` passes (unit tests; integration tests require Docker)
- [x] `grep -r CrawlTaskQueue` returns no results across `dspm-connector-templates` and `dspm-connectors` after running `make templates-update`

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>