### PR TITLE
AB#433610 — Warning: SIGTERM received — ApplicationStopping triggered; job will be cancelled

### DIFF
--- a/template/netwrix-csharp/ConnectorFramework/Program.cs
+++ b/template/netwrix-csharp/ConnectorFramework/Program.cs
@@ -157,9 +157,6 @@ internal static class Program
             var handlerInstance = scope.ServiceProvider.GetRequiredService<IConnectorHandler>();
             var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
 
-            lifetime.ApplicationStopping.Register(() =>
-                logger.LogWarning("SIGTERM received — ApplicationStopping triggered; job will be cancelled"));
-
             isLongRunning = requestData.Execution.IsLongRunning;
 
             using (logger.BeginScope(new Dictionary<string, object?>
@@ -184,6 +181,8 @@ internal static class Program
 
                 object result;
                 using (var handleActivity = ActivitySource.StartActivity("handle_request"))
+                using (lifetime.ApplicationStopping.Register(() =>
+                    logger.LogWarning("SIGTERM received — ApplicationStopping triggered; job will be cancelled")))
                 {
                     result = await handlerInstance.HandleJobAsync(requestData, context, lifetime.ApplicationStopping);
                 }


### PR DESCRIPTION
## Summary

- Moves the `ApplicationStopping` callback registration into a `using` block scoped to `HandleJobAsync`, so it is automatically unregistered when the handler returns
- Previously the registration was placed unconditionally before the handler, meaning `host.StopAsync()` on normal shutdown triggered the warning on every successful scan
- No behaviour change for actual SIGTERM-during-execution: the warning still fires if cancellation arrives while the handler is in flight

## Test plan

- [x] Run a full SPO Access scan to completion — confirm no SIGTERM warning appears in logs
- [x] Run an Entra ID Identity Sync to completion — confirm no SIGTERM warning appears in logs
- [x] Simulate an actual SIGTERM mid-scan (e.g. `kubectl delete pod`) — confirm the warning still fires as expected

AB#433610