### PR TITLE
AB#433121 — Remove per-connector InternalsVisibleTo coupling from framework template

### DIFF
--- a/template/netwrix-csharp/ConnectorFramework.Testing/ConnectorFramework.Testing.csproj
+++ b/template/netwrix-csharp/ConnectorFramework.Testing/ConnectorFramework.Testing.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- CA2007: ConfigureAwait — not needed in test-support code -->
+    <NoWarn>CA2007</NoWarn>
+    <AssemblyName>ConnectorFramework.Testing</AssemblyName>
+    <RootNamespace>Netwrix.ConnectorFramework.Testing</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../ConnectorFramework/ConnectorFramework.csproj" />
+  </ItemGroup>
+
+  <!-- Explicit SDK refs so connector test consumers can reference their types without indirect deps -->
+  <ItemGroup>
+    <PackageReference Include="Netwrix.Overlord.Sdk.Cloud" Version="2.0.0.14-preview" />
+    <PackageReference Include="Netwrix.Overlord.Sdk.Core" Version="2.0.0.14-preview" />
+    <PackageReference Include="Netwrix.Overlord.Sdk.Orchestration" Version="2.0.0.14-preview" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.*" />
+  </ItemGroup>
+
+</Project>

--- a/template/netwrix-csharp/ConnectorFramework.Testing/ConnectorFrameworkTestServiceExtensions.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Testing/ConnectorFrameworkTestServiceExtensions.cs
@@ -1,0 +1,61 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Netwrix.ConnectorFramework;
+using Netwrix.Overlord.Sdk.Orchestration;
+
+namespace Netwrix.ConnectorFramework.Testing;
+
+/// <summary>
+/// Extension methods for registering ConnectorFramework scoped services in connector test projects.
+/// </summary>
+public static class ConnectorFrameworkTestServiceExtensions
+{
+    /// <summary>
+    /// Registers the ConnectorFramework scoped services that <c>Program.cs</c> wires up at runtime,
+    /// so connector test projects can invoke <c>Handler.HandleJobAsync</c> or
+    /// <c>Handler.RunScanAsync</c> without referencing internal types directly.
+    /// </summary>
+    /// <remarks>
+    /// Callers must separately register:
+    /// <list type="bullet">
+    ///   <item><description><see cref="IStateStorage"/> (e.g. an in-memory implementation)</description></item>
+    ///   <item><description><see cref="IRunStateStorageFactory"/></description></item>
+    ///   <item><description><see cref="ICrawlRunOrchestrator"/> (real or mock)</description></item>
+    ///   <item><description>Logging (<c>services.AddLogging()</c>)</description></item>
+    ///   <item><description>Configuration (<c>services.AddSingleton&lt;IConfiguration&gt;(...)</c>)</description></item>
+    ///   <item><description><c>IHttpClientFactory</c></description></item>
+    /// </list>
+    /// </remarks>
+    public static IServiceCollection AddConnectorFrameworkTestServices(
+        this IServiceCollection services)
+    {
+        // Internal type: not directly referenceable from connector test projects.
+        services.AddScoped<RequestDataHolder>();
+        services.AddScoped<ConnectorRequestData>(
+            sp => sp.GetRequiredService<RequestDataHolder>().Data);
+
+        // ConnectorStateClient is sealed — create a no-op instance.
+        // ScanExecutionId=null makes UpdateExecutionAsync a no-op, so the HttpClient is never called.
+        services.AddScoped(sp =>
+            new ConnectorStateClient(
+                new HttpClient(),
+                sp.GetRequiredService<ILoggerFactory>().CreateLogger<ConnectorStateClient>()));
+
+        services.AddScoped<FunctionContext>();
+        services.AddScoped<IScanProgress>(sp => sp.GetRequiredService<FunctionContext>());
+        services.AddScoped<IScanWriter>(sp => sp.GetRequiredService<FunctionContext>());
+
+        services.AddScoped<AACorePlatformFacade>();
+        services.AddScoped<AACrawlTaskCorePlatformFacade>(sp =>
+            new AACrawlTaskCorePlatformFacade(
+                sp.GetRequiredService<AACorePlatformFacade>(),
+                sp.GetRequiredService<IScanProgress>(),
+                sp.GetRequiredService<ILoggerFactory>()
+                    .CreateLogger<AACrawlTaskCorePlatformFacade>()));
+        services.AddSingleton<AACrawlTaskFacadeHolder>();
+
+        services.AddOptions<CrawlRunOrchestratorOptions>();
+
+        return services;
+    }
+}

--- a/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorFramework.Tests.csproj
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorFramework.Tests.csproj
@@ -31,6 +31,8 @@
     <PackageReference Include="Netwrix.Overlord.Sdk.Core" Version="2.0.0.14-preview" />
     <PackageReference Include="Netwrix.Overlord.Sdk.Orchestration" Version="2.0.0.14-preview" />
     <PackageReference Include="Microsoft.Extensions.Resilience" Version="8.*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.*" />
+    <PackageReference Include="Testcontainers.Redis" Version="3.*" />
   </ItemGroup>
 
 </Project>

--- a/template/netwrix-csharp/ConnectorFramework.Tests/CrawlRunOrchestratorIntegrationTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/CrawlRunOrchestratorIntegrationTests.cs
@@ -1,0 +1,98 @@
+using Microsoft.Extensions.DependencyInjection;
+using Netwrix.ConnectorFramework.Tests.TestHelpers;
+using Netwrix.Overlord.Sdk.Cloud.TaskScheduler;
+using Netwrix.Overlord.Sdk.Core.Exceptions;
+using Netwrix.Overlord.Sdk.Orchestration;
+using Xunit;
+
+namespace Netwrix.ConnectorFramework.Tests;
+
+/// <summary>
+/// Integration tests for the CrawlRunOrchestrator path wired in by T-008.
+/// Uses in-memory test doubles — no Docker, Redis, or external services required.
+/// </summary>
+public class CrawlRunOrchestratorIntegrationTests
+{
+    [Fact]
+    public async Task SingleTask_CompletesSuccessfully()
+    {
+        var processorFactory = new TestCrawlTaskProcessorFactory();
+        var stateStorageFactory = new InMemoryRunStateStorageFactory();
+        var request = OrchestratorTestHarness.BuildRequest(Guid.NewGuid());
+
+        await using var container = OrchestratorTestHarness.BuildContainer(processorFactory, stateStorageFactory);
+        var orchestrator = container.GetRequiredService<ICrawlRunOrchestrator>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var exitReason = await orchestrator.RunAsync(request, cts.Token);
+
+        Assert.Equal(CrawlRunExitReason.Completed, exitReason);
+        Assert.Equal(1, processorFactory.CallCount);
+    }
+
+    [Fact]
+    public async Task TransientException_WithinBudget_RetriesAndCompletes()
+    {
+        // Processor throws TransientException on call 0, succeeds on call 1.
+        // CrawlAttemptTracker starts at 1 on first registration, so MaxAttempts=2 gives one re-queue:
+        // attempt=1 < 2 on first dispatch → re-queue; attempt=2 on second dispatch → succeeds → Completed.
+        var processorFactory = new TestCrawlTaskProcessorFactory(
+            exceptionForCall: callIndex => callIndex == 0
+                ? new TransientException("transient", new Exception("inner"))
+                : null);
+        var stateStorageFactory = new InMemoryRunStateStorageFactory();
+        var request = OrchestratorTestHarness.BuildRequest(Guid.NewGuid());
+
+        await using var container = OrchestratorTestHarness.BuildContainer(
+            processorFactory, stateStorageFactory,
+            configureOptions: o => o.MaxAttempts = 2);
+        var orchestrator = container.GetRequiredService<ICrawlRunOrchestrator>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var exitReason = await orchestrator.RunAsync(request, cts.Token);
+
+        Assert.Equal(CrawlRunExitReason.Completed, exitReason);
+        Assert.Equal(2, processorFactory.CallCount); // call 0 (transient → re-queued) + call 1 (success)
+    }
+
+    [Fact]
+    public async Task TransientException_BudgetExhausted_ScanCompletesWithDeadLetter()
+    {
+        // Processor always throws. MaxAttempts=2: attempt=1 < 2 → re-queue; attempt=2 < 2 → false → dead-letter.
+        // The scan still exits Completed — a dead-lettered task does not fail the run.
+        var processorFactory = new TestCrawlTaskProcessorFactory(
+            exceptionForCall: _ => new TransientException("transient", new Exception("inner")));
+        var stateStorageFactory = new InMemoryRunStateStorageFactory();
+        var crawlRunRef = Guid.NewGuid();
+        var request = OrchestratorTestHarness.BuildRequest(crawlRunRef);
+
+        await using var container = OrchestratorTestHarness.BuildContainer(
+            processorFactory, stateStorageFactory,
+            configureOptions: o => o.MaxAttempts = 2);
+        var orchestrator = container.GetRequiredService<ICrawlRunOrchestrator>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var exitReason = await orchestrator.RunAsync(request, cts.Token);
+
+        Assert.Equal(CrawlRunExitReason.Completed, exitReason);
+        Assert.Equal(2, processorFactory.CallCount); // call 0 (re-queued) + call 1 (dead-lettered)
+
+        var deadLetterPrefix = StateStorageKeys.RunScoped(crawlRunRef.ToString(), "dead-letters");
+        var deadLetterKeys = new List<string>();
+        await foreach (var key in stateStorageFactory.Storage.ListAllKeysAsync(deadLetterPrefix, cts.Token))
+        {
+            deadLetterKeys.Add(key);
+        }
+        Assert.Single(deadLetterKeys);
+    }
+
+    // AuthException thrown from ICrawlTaskProcessor.Crawl() is caught by
+    // CrawlTaskRequestHandler.ProcessCrawlTask() before it reaches the orchestrator's
+    // DispatchTaskAsync catch (AuthException) block. The ConfigCache invalidation + retry
+    // path in CrawlRunOrchestrator is therefore unreachable via the processor.
+    // See: platform-1secure/Tests/UnitTests/Netwrix.Overlord.Sdk.Orchestration.Test/Tests/CrawlRunOrchestratorTests.cs
+    [Fact(Skip = "AuthException never escapes CrawlTaskRequestHandler.ProcessCrawlTask() — " +
+                 "ConfigCache invalidation path in CrawlRunOrchestrator is unreachable via the processor")]
+    public Task AuthException_NeverEscapesProcessCrawlTask_ConfigCacheRetryPathUnreachable()
+        => Task.CompletedTask;
+}

--- a/template/netwrix-csharp/ConnectorFramework.Tests/CrawlRunOrchestratorRedisIntegrationTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/CrawlRunOrchestratorRedisIntegrationTests.cs
@@ -6,6 +6,7 @@ using Netwrix.Overlord.Sdk.Cloud.TaskScheduler.Models;
 using Netwrix.Overlord.Sdk.Core.Crawling;
 using Netwrix.Overlord.Sdk.Orchestration;
 using StackExchange.Redis;
+using System.Net.Sockets;
 using System.Text.Json;
 using Testcontainers.Redis;
 using Xunit;
@@ -29,7 +30,30 @@ public sealed class CrawlRunOrchestratorRedisIntegrationTests : IAsyncLifetime
     public async Task InitializeAsync()
     {
         await _redisContainer.StartAsync();
+        // On Rancher Desktop (Lima VM), port forwarding to the macOS host takes a few seconds
+        // after the container's own ready check passes. Poll until the TCP port is reachable.
+        await WaitForTcpPortAsync(_redisContainer.GetConnectionString());
         _redis = ConnectionMultiplexer.Connect(_redisContainer.GetConnectionString());
+    }
+
+    private static async Task WaitForTcpPortAsync(string connectionString, int timeoutSeconds = 10)
+    {
+        var cfg = ConfigurationOptions.Parse(connectionString);
+        var ep = (System.Net.IPEndPoint)cfg.EndPoints[0];
+        using var deadline = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds));
+        while (true)
+        {
+            try
+            {
+                using var tcp = new TcpClient();
+                await tcp.ConnectAsync(ep.Address, ep.Port, deadline.Token);
+                return;
+            }
+            catch (Exception) when (!deadline.IsCancellationRequested)
+            {
+                await Task.Delay(200, deadline.Token);
+            }
+        }
     }
 
     public async Task DisposeAsync()

--- a/template/netwrix-csharp/ConnectorFramework.Tests/CrawlRunOrchestratorRedisIntegrationTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/CrawlRunOrchestratorRedisIntegrationTests.cs
@@ -1,0 +1,153 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Netwrix.ConnectorFramework.Tests.TestHelpers;
+using Netwrix.Overlord.Sdk.Cloud.TaskScheduler;
+using Netwrix.Overlord.Sdk.Cloud.TaskScheduler.Models;
+using Netwrix.Overlord.Sdk.Core.Crawling;
+using Netwrix.Overlord.Sdk.Orchestration;
+using StackExchange.Redis;
+using System.Text.Json;
+using Testcontainers.Redis;
+using Xunit;
+
+namespace Netwrix.ConnectorFramework.Tests;
+
+/// <summary>
+/// Integration tests for <see cref="AA26CrawlRunSignalSource"/> against a real Redis instance.
+/// Verifies that control signals written to the Redis stream correctly drive the orchestrator.
+///
+/// Requires Docker.
+/// On Rancher Desktop (macOS): set DOCKER_HOST=unix:///~/.rd/docker.sock and
+/// TESTCONTAINERS_RYUK_DISABLED=true before running.
+/// </summary>
+[Trait("Category", "Integration")]
+public sealed class CrawlRunOrchestratorRedisIntegrationTests : IAsyncLifetime
+{
+    private readonly RedisContainer _redisContainer = new RedisBuilder().Build();
+    private IConnectionMultiplexer _redis = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _redisContainer.StartAsync();
+        _redis = ConnectionMultiplexer.Connect(_redisContainer.GetConnectionString());
+    }
+
+    public async Task DisposeAsync()
+    {
+        _redis.Dispose();
+        await _redisContainer.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task StopSignalInRedis_TerminatesRun()
+    {
+        var processorFactory = new TestCrawlTaskProcessorFactory(
+            childrenForCall: callIndex => callIndex == 0
+                ? Enumerable.Range(0, 5).Select(i => new CrawlItemTask
+                {
+                    Reference = Guid.NewGuid(),
+                    ItemType = null,
+                    ItemExternalReference = $"child-{i}",
+                    ItemName = $"Child {i}",
+                    AllowImmediateProcessing = false,
+                }).ToList()
+                : Array.Empty<CrawlItemTask>());
+
+        var stateStorageFactory = new InMemoryRunStateStorageFactory();
+        var crawlRunRef = Guid.NewGuid();
+        var request = OrchestratorTestHarness.BuildRequest(crawlRunRef);
+
+        var loggerFactory = LoggerFactory.Create(b => b.SetMinimumLevel(LogLevel.Warning));
+        var signalSource = new AA26CrawlRunSignalSource(
+            new RedisSignalHandler(_redis, loggerFactory.CreateLogger<RedisSignalHandler>()));
+
+        await using var container = OrchestratorTestHarness.BuildContainer(
+            processorFactory, stateStorageFactory, signalSource);
+
+        var orchestrator = container.GetRequiredService<ICrawlRunOrchestrator>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        // Hold root task so we can inject STOP before children are enqueued.
+        processorFactory.HoldNextCrawl();
+        var runTask = orchestrator.RunAsync(request, cts.Token);
+
+        var signalWait = processorFactory.WaitForCallAsync(cts.Token);
+        await Task.WhenAny(runTask, signalWait);
+        if (runTask.IsCompleted) await runTask;
+        await signalWait;
+
+        // Write STOP to Redis — orchestrator reads it on the next signal check.
+        await _redis.GetDatabase().StreamAddAsync(
+            $"scan:control:{crawlRunRef}",
+            [new NameValueEntry("action", "STOP")]);
+
+        processorFactory.UnblockCrawl();
+
+        var exitReason = await runTask;
+        Assert.Equal(CrawlRunExitReason.Stopped, exitReason);
+        Assert.True(processorFactory.CallCount < 6,
+            $"Expected Stop to terminate early; got callCount={processorFactory.CallCount}");
+    }
+
+    [Fact]
+    public async Task PauseSignalInRedis_PersistsQueueAndResumes()
+    {
+        var crawlRunRef = Guid.NewGuid();
+        const int totalChildren = 9;
+        var processorFactory = new TestCrawlTaskProcessorFactory(
+            childrenForCall: callIndex => callIndex == 0
+                ? Enumerable.Range(0, totalChildren).Select(i => new CrawlItemTask
+                {
+                    Reference = Guid.NewGuid(),
+                    ItemType = null,
+                    ItemExternalReference = $"child-{i}",
+                    ItemName = $"Child {i}",
+                    AllowImmediateProcessing = false,
+                }).ToList()
+                : Array.Empty<CrawlItemTask>());
+
+        var stateStorageFactory = new InMemoryRunStateStorageFactory();
+        var request = OrchestratorTestHarness.BuildRequest(crawlRunRef);
+
+        var loggerFactory = LoggerFactory.Create(b => b.SetMinimumLevel(LogLevel.Warning));
+        var signalSource = new AA26CrawlRunSignalSource(
+            new RedisSignalHandler(_redis, loggerFactory.CreateLogger<RedisSignalHandler>()));
+
+        await using var container = OrchestratorTestHarness.BuildContainer(
+            processorFactory, stateStorageFactory, signalSource);
+
+        var orchestrator = container.GetRequiredService<ICrawlRunOrchestrator>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        // ── Phase 1: Pause ────────────────────────────────────────────────────────
+        // Hold root task and inject PAUSE before its children are enqueued.
+        processorFactory.HoldNextCrawl();
+        var run1Task = orchestrator.RunAsync(request, cts.Token);
+
+        var signalWait1 = processorFactory.WaitForCallAsync(cts.Token);
+        await Task.WhenAny(run1Task, signalWait1);
+        if (run1Task.IsCompleted) await run1Task;
+        await signalWait1;
+
+        await _redis.GetDatabase().StreamAddAsync(
+            $"scan:control:{crawlRunRef}",
+            [new NameValueEntry("action", "PAUSE")]);
+
+        processorFactory.UnblockCrawl();
+
+        var run1ExitReason = await run1Task;
+        Assert.Equal(CrawlRunExitReason.Paused, run1ExitReason);
+
+        var queueKey = StateStorageKeys.RunScoped(crawlRunRef.ToString(), "queue-state");
+        var snapshot = await stateStorageFactory.Storage.TryGetAsync<JsonElement>(queueKey, cts.Token);
+        Assert.True(snapshot.IsSuccess, "Queue snapshot should be persisted after pause.");
+
+        // ── Phase 2: Resume ───────────────────────────────────────────────────────
+        var run2ExitReason = await orchestrator.RunAsync(request, cts.Token);
+        Assert.Equal(CrawlRunExitReason.Completed, run2ExitReason);
+
+        var queueAfterResume = await stateStorageFactory.Storage.TryGetAsync<JsonElement>(queueKey, cts.Token);
+        Assert.False(queueAfterResume.IsSuccess, "Queue snapshot should be deleted after resume completes.");
+        Assert.Equal(totalChildren + 1, processorFactory.CallCount);
+    }
+}

--- a/template/netwrix-csharp/ConnectorFramework.Tests/OrchestratorOptionsTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/OrchestratorOptionsTests.cs
@@ -1,0 +1,151 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Netwrix.Overlord.Sdk.Orchestration;
+using Xunit;
+
+namespace Netwrix.ConnectorFramework.Tests;
+
+// Process-level env vars mutated in these tests are not thread-safe across parallel runs.
+// Run this collection sequentially to avoid flaky interference with other test classes.
+[Collection("Sequential")]
+public class OrchestratorOptionsTests
+{
+    private static IOptions<CrawlRunOrchestratorOptions> BuildOptions(Action<CrawlRunOrchestratorOptions>? seed = null)
+    {
+        var services = new ServiceCollection();
+        var builder = services.AddOptions<CrawlRunOrchestratorOptions>();
+        if (seed is not null)
+            builder.Configure(seed);
+        builder.PostConfigure(CrawlRunOrchestratorServiceExtensions.ApplyOrchestratorEnvVarOverrides);
+        var sp = services.BuildServiceProvider();
+        return sp.GetRequiredService<IOptions<CrawlRunOrchestratorOptions>>();
+    }
+
+    [Fact]
+    public void MaxWorkers_DefaultPreserved_WhenEnvVarAbsent()
+    {
+        Environment.SetEnvironmentVariable("MAX_WORKERS", null);
+        var opts = BuildOptions(o => o.MaxWorkers = 3).Value;
+        Assert.Equal(3, opts.MaxWorkers);
+    }
+
+    [Fact]
+    public void MaxWorkers_OverriddenByEnvVar()
+    {
+        Environment.SetEnvironmentVariable("MAX_WORKERS", "10");
+        try
+        {
+            var opts = BuildOptions(o => o.MaxWorkers = 3).Value;
+            Assert.Equal(10, opts.MaxWorkers);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MAX_WORKERS", null);
+        }
+    }
+
+    [Fact]
+    public void MaxConcurrencyPerSource_OverriddenByEnvVar()
+    {
+        Environment.SetEnvironmentVariable("MAX_CONCURRENCY_PER_SOURCE", "6");
+        try
+        {
+            var opts = BuildOptions().Value;
+            Assert.Equal(6, opts.MaxConcurrencyPerSource);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MAX_CONCURRENCY_PER_SOURCE", null);
+        }
+    }
+
+    [Fact]
+    public void MaxAttempts_OverriddenByEnvVar()
+    {
+        Environment.SetEnvironmentVariable("MAX_ATTEMPTS", "7");
+        try
+        {
+            var opts = BuildOptions().Value;
+            Assert.Equal(7, opts.MaxAttempts);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MAX_ATTEMPTS", null);
+        }
+    }
+
+    [Fact]
+    public void MaxAuthRetryAttempts_OverriddenByEnvVar()
+    {
+        Environment.SetEnvironmentVariable("MAX_AUTH_RETRY_ATTEMPTS", "4");
+        try
+        {
+            var opts = BuildOptions().Value;
+            Assert.Equal(4, opts.MaxAuthRetryAttempts);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MAX_AUTH_RETRY_ATTEMPTS", null);
+        }
+    }
+
+    [Fact]
+    public void MaxHashMismatchAttempts_OverriddenByEnvVar()
+    {
+        Environment.SetEnvironmentVariable("MAX_HASH_MISMATCH_ATTEMPTS", "2");
+        try
+        {
+            var opts = BuildOptions().Value;
+            Assert.Equal(2, opts.MaxHashMismatchAttempts);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MAX_HASH_MISMATCH_ATTEMPTS", null);
+        }
+    }
+
+    [Fact]
+    public void MaxQueueDepth_OverriddenByEnvVar()
+    {
+        Environment.SetEnvironmentVariable("MAX_QUEUE_DEPTH", "500");
+        try
+        {
+            var opts = BuildOptions().Value;
+            Assert.Equal(500, opts.MaxQueueDepth);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MAX_QUEUE_DEPTH", null);
+        }
+    }
+
+    [Fact]
+    public void ConfigCacheTtlMinutes_OverriddenByEnvVar()
+    {
+        Environment.SetEnvironmentVariable("CONFIG_CACHE_TTL_MINUTES", "45");
+        try
+        {
+            var opts = BuildOptions().Value;
+            Assert.Equal(TimeSpan.FromMinutes(45), opts.ConfigCacheTtl);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CONFIG_CACHE_TTL_MINUTES", null);
+        }
+    }
+
+    [Fact]
+    public void NonInteger_IsIgnored_DefaultPreserved()
+    {
+        Environment.SetEnvironmentVariable("MAX_WORKERS", "not-a-number");
+        try
+        {
+            var opts = BuildOptions(o => o.MaxWorkers = 5).Value;
+            Assert.Equal(5, opts.MaxWorkers);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MAX_WORKERS", null);
+        }
+    }
+}

--- a/template/netwrix-csharp/ConnectorFramework.Tests/TestHelpers/FakeCrawlTaskFacade.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/TestHelpers/FakeCrawlTaskFacade.cs
@@ -1,0 +1,80 @@
+using System.Text.Json.Nodes;
+using Netwrix.Overlord.Sdk.Cloud;
+using Netwrix.Overlord.Sdk.Cloud.TaskScheduler;
+using Netwrix.Overlord.Sdk.Cloud.TaskScheduler.Models;
+using Netwrix.Overlord.Sdk.Cloud.TaskScheduler.Models.Api;
+using Netwrix.Overlord.Sdk.Core.Activity.Models;
+using Netwrix.Overlord.Sdk.Core.State.Models;
+
+namespace Netwrix.ConnectorFramework.Tests.TestHelpers;
+
+/// <summary>
+/// Test double for <see cref="ICrawlTaskManagementPlatformFacade"/> used in integration tests
+/// that need to react to <see cref="FinaliseTask"/> calls (e.g. to inject a control signal
+/// into Redis after a specific number of completions).
+/// </summary>
+internal sealed class FakeCrawlTaskFacade : ICrawlTaskManagementPlatformFacade
+{
+    private int _finaliseCount;
+    private readonly Func<int, Task>? _onFinalise;
+
+    private static readonly CrawlTaskConfiguration DefaultConfig = new()
+    {
+        Source = new CrawlTaskConfiguration.SourcePayload
+        {
+            Name = "test-source",
+            Reference = Guid.NewGuid(),
+            ExternalReference = "test-tenant",
+            CredentialsId = Guid.Empty,
+            Enabled = true,
+        },
+        ConnectorConfigs = [],
+        FeatureFlags = [],
+    };
+
+    /// <summary>Total number of <see cref="FinaliseTask"/> calls received (all update types).</summary>
+    public int FinaliseCount => Volatile.Read(ref _finaliseCount);
+
+    /// <param name="onFinalise">
+    /// Optional callback invoked after each <see cref="FinaliseTask"/> call,
+    /// receiving the running total. Use to inject Redis signals at precise moments.
+    /// </param>
+    public FakeCrawlTaskFacade(Func<int, Task>? onFinalise = null)
+    {
+        _onFinalise = onFinalise;
+    }
+
+    public Task<CrawlTaskConfiguration> StartTask(Guid crawlTaskReference, DateTimeOffset startDate)
+        => Task.FromResult(DefaultConfig);
+
+    public async Task FinaliseTask(APICrawlTaskProgress taskProgress)
+    {
+        var count = Interlocked.Increment(ref _finaliseCount);
+        if (_onFinalise is not null)
+            await _onFinalise(count);
+    }
+
+    public Task EnsureRegularTaskProgressUpdate(Guid taskReference, CrawlResponse taskProgress)
+        => Task.CompletedTask;
+
+    public Task<TMessage> DecryptServiceBusMessage<TMessage>(string message)
+        => throw new NotSupportedException("Not used in integration tests.");
+
+    public Task<TData> DecryptData<TData>(byte[] encryptedKey, byte[] encryptedPayload)
+        => throw new NotSupportedException("Not used in integration tests.");
+
+    public Task UploadActivityRecords(List<ActivityRecord> activityRecords)
+        => Task.CompletedTask;
+
+    public Task UploadSiTRecords(CrawlContext context, List<SitObjectImportModel> objectModels,
+        List<SitMappingImportModel> mappingModels, List<SitImportActionModel> actionModels,
+        bool isFinal, int chunkId = 1)
+        => Task.CompletedTask;
+
+    public Task UploadSiTSchemaRecords(CrawlContext context, string tableName,
+        IReadOnlyList<JsonObject> entities, bool isFinal, int chunkId = 1)
+        => Task.CompletedTask;
+
+    public Task<TData> DecryptTenancyData<TData>(byte[] encryptedKey, byte[] encryptedPayload)
+        => throw new NotSupportedException("Not used in integration tests.");
+}

--- a/template/netwrix-csharp/ConnectorFramework.Tests/TestHelpers/FakeFunctionContext.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/TestHelpers/FakeFunctionContext.cs
@@ -1,0 +1,92 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Netwrix.ConnectorFramework.Tests.TestHelpers;
+
+/// <summary>
+/// In-memory IFunctionContext for unit tests. Pre-seed secrets and state via the constructor;
+/// inspect captured UpdateExecutionAsync calls via <see cref="ExecutionUpdates"/>.
+/// </summary>
+public sealed class FakeFunctionContext : IFunctionContext
+{
+    private Dictionary<string, string>? _state;
+
+    public FakeFunctionContext(
+        Dictionary<string, string>? secrets = null,
+        Dictionary<string, string>? initialState = null,
+        ExecutionContext? execution = null)
+    {
+        Secrets = secrets ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        _state = initialState;
+        Execution = execution ?? new ExecutionContext(
+            ScanId: "test-scan",
+            ScanExecutionId: "test-execution",
+            SourceId: "test-source",
+            SourceType: "test",
+            SourceVersion: null,
+            FunctionType: "access-scan");
+        Request = new ConnectorRequestData(
+            Method: "POST",
+            Path: "/connector/access_scan",
+            Headers: new Dictionary<string, string>(),
+            Body: null,
+            Execution: Execution);
+    }
+
+    public ExecutionContext Execution { get; }
+    public ILogger Log => NullLogger.Instance;
+    public IReadOnlyDictionary<string, string> Secrets { get; }
+    public ConnectorRequestData Request { get; }
+
+    public List<UpdateExecutionCall> ExecutionUpdates { get; } = new();
+
+    public Activity? StartActivity(string name) => null;
+
+    /// <summary>
+    /// Not supported — BatchManager requires real HTTP infrastructure.
+    /// Connector unit tests should inject IScanWriter directly.
+    /// </summary>
+    public BatchManager GetTable(string tableName)
+        => throw new NotSupportedException(
+            "GetTable is not available in FakeFunctionContext. " +
+            "Inject IScanWriter directly for unit tests that need data capture.");
+
+    public Task UpdateExecutionAsync(
+        string? status = null,
+        int? totalObjects = null,
+        int? completedObjects = null,
+        DateTimeOffset? completedAt = null,
+        int incrementCompletedObjects = 0,
+        CancellationToken ct = default)
+    {
+        ExecutionUpdates.Add(new UpdateExecutionCall(status, totalObjects, completedObjects, completedAt, incrementCompletedObjects));
+        return Task.CompletedTask;
+    }
+
+    public Task<Dictionary<string, string>?> GetConnectorStateAsync(CancellationToken ct = default)
+        => Task.FromResult(_state);
+
+    public Task SetConnectorStateAsync(Dictionary<string, object?> data, CancellationToken ct = default)
+    {
+        _state ??= new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var (key, value) in data)
+        {
+            if (value is not null)
+            {
+                _state[key] = value.ToString() ?? string.Empty;
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task FlushTablesAsync(CancellationToken ct = default) => Task.CompletedTask;
+}
+
+public sealed record UpdateExecutionCall(
+    string? Status,
+    int? TotalObjects,
+    int? CompletedObjects,
+    DateTimeOffset? CompletedAt,
+    int IncrementCompletedObjects);

--- a/template/netwrix-csharp/ConnectorFramework.Tests/TestHelpers/OrchestratorTestHarness.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/TestHelpers/OrchestratorTestHarness.cs
@@ -30,7 +30,8 @@ internal static class OrchestratorTestHarness
     public static ServiceProvider BuildContainer(
         TestCrawlTaskProcessorFactory processorFactory,
         InMemoryRunStateStorageFactory stateStorageFactory,
-        ICrawlRunSignalSource? signalSource = null)
+        ICrawlRunSignalSource? signalSource = null,
+        Action<CrawlRunOrchestratorOptions>? configureOptions = null)
     {
         var services = new ServiceCollection();
         var emptyConfig = new ConfigurationBuilder().Build();
@@ -50,6 +51,7 @@ internal static class OrchestratorTestHarness
             o.MaxAuthRetryAttempts = 1;
             o.MaxHashMismatchAttempts = 1;
             o.ConfigCacheTtl = TimeSpan.FromMinutes(5);
+            configureOptions?.Invoke(o);
         });
 
         services.AddSingleton<IRunStateStorageFactory>(stateStorageFactory);

--- a/template/netwrix-csharp/ConnectorFramework.Tests/TestHelpers/TestCrawlTaskProcessorFactory.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/TestHelpers/TestCrawlTaskProcessorFactory.cs
@@ -11,6 +11,7 @@ internal sealed class TestCrawlTaskProcessorFactory : ICrawlTaskProcessorFactory
 {
     private int _callCount;
     private readonly Func<int, IReadOnlyList<CrawlItemTask>> _childrenForCall;
+    private readonly Func<int, Exception?>? _exceptionForCall;
 
     // Released once per call so tests can synchronize on task start.
     private readonly SemaphoreSlim _taskStartedSignal = new(0);
@@ -19,8 +20,13 @@ internal sealed class TestCrawlTaskProcessorFactory : ICrawlTaskProcessorFactory
     // Cleared atomically when consumed so only the intended processor is held.
     private TaskCompletionSource<bool>? _nextCrawlBlocker;
 
-    public TestCrawlTaskProcessorFactory(Func<int, IReadOnlyList<CrawlItemTask>> childrenForCall)
-        => _childrenForCall = childrenForCall;
+    public TestCrawlTaskProcessorFactory(
+        Func<int, IReadOnlyList<CrawlItemTask>>? childrenForCall = null,
+        Func<int, Exception?>? exceptionForCall = null)
+    {
+        _childrenForCall = childrenForCall ?? (_ => Array.Empty<CrawlItemTask>());
+        _exceptionForCall = exceptionForCall;
+    }
 
     public int CallCount => _callCount;
 
@@ -51,8 +57,9 @@ internal sealed class TestCrawlTaskProcessorFactory : ICrawlTaskProcessorFactory
         // With MaxWorkers=1 only one processor is in-flight at a time, so all processors
         // created after UnblockCrawl() will get an already-completed Task and won't block.
         var blocker = _nextCrawlBlocker?.Task;
+        var exception = _exceptionForCall?.Invoke(index);
         _taskStartedSignal.Release();
-        return new TestCrawlTaskProcessor(_childrenForCall(index), blocker);
+        return new TestCrawlTaskProcessor(_childrenForCall(index), blocker, exception);
     }
 }
 
@@ -60,11 +67,13 @@ internal sealed class TestCrawlTaskProcessor : ICrawlTaskProcessor
 {
     private readonly IReadOnlyList<CrawlItemTask> _children;
     private readonly Task? _blocker;
+    private readonly Exception? _exception;
 
-    public TestCrawlTaskProcessor(IReadOnlyList<CrawlItemTask> children, Task? blocker = null)
+    public TestCrawlTaskProcessor(IReadOnlyList<CrawlItemTask> children, Task? blocker = null, Exception? exception = null)
     {
         _children = children;
         _blocker = blocker;
+        _exception = exception;
     }
 
     public async Task<CrawlResponse> Crawl(CancellationToken cancellationToken)
@@ -72,6 +81,11 @@ internal sealed class TestCrawlTaskProcessor : ICrawlTaskProcessor
         if (_blocker is not null)
         {
             await _blocker.WaitAsync(cancellationToken);
+        }
+
+        if (_exception is not null)
+        {
+            throw _exception;
         }
 
         return new CrawlResponse

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorFramework.csproj
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorFramework.csproj
@@ -16,6 +16,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>ConnectorFramework.Tests</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>ConnectorFramework.Testing</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorFramework.csproj
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorFramework.csproj
@@ -14,16 +14,7 @@
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>FakeFs.Tests</_Parameter1>
-    </AssemblyAttribute>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>ConnectorFramework.Tests</_Parameter1>
-    </AssemblyAttribute>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>SharepointOnline.Tests</_Parameter1>
-    </AssemblyAttribute>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>EntraId.Sync.Tests</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/template/netwrix-csharp/ConnectorFramework/CrawlRunOrchestratorServiceExtensions.cs
+++ b/template/netwrix-csharp/ConnectorFramework/CrawlRunOrchestratorServiceExtensions.cs
@@ -1,0 +1,33 @@
+using Netwrix.Overlord.Sdk.Orchestration;
+
+namespace Netwrix.ConnectorFramework;
+
+public static class CrawlRunOrchestratorServiceExtensions
+{
+    /// <summary>
+    /// Applies <see cref="CrawlRunOrchestratorOptions"/> overrides from environment variables.
+    /// Call via <c>PostConfigure</c> so environment variables win over code defaults.
+    /// </summary>
+    /// <remarks>
+    /// Recognised variables: MAX_WORKERS, MAX_CONCURRENCY_PER_SOURCE, MAX_ATTEMPTS,
+    /// MAX_AUTH_RETRY_ATTEMPTS, MAX_HASH_MISMATCH_ATTEMPTS, MAX_QUEUE_DEPTH,
+    /// CONFIG_CACHE_TTL_MINUTES.
+    /// </remarks>
+    public static void ApplyOrchestratorEnvVarOverrides(CrawlRunOrchestratorOptions opts)
+    {
+        if (int.TryParse(Environment.GetEnvironmentVariable("MAX_WORKERS"), out var v))
+            opts.MaxWorkers = v;
+        if (int.TryParse(Environment.GetEnvironmentVariable("MAX_CONCURRENCY_PER_SOURCE"), out v))
+            opts.MaxConcurrencyPerSource = v;
+        if (int.TryParse(Environment.GetEnvironmentVariable("MAX_ATTEMPTS"), out v))
+            opts.MaxAttempts = v;
+        if (int.TryParse(Environment.GetEnvironmentVariable("MAX_AUTH_RETRY_ATTEMPTS"), out v))
+            opts.MaxAuthRetryAttempts = v;
+        if (int.TryParse(Environment.GetEnvironmentVariable("MAX_HASH_MISMATCH_ATTEMPTS"), out v))
+            opts.MaxHashMismatchAttempts = v;
+        if (int.TryParse(Environment.GetEnvironmentVariable("MAX_QUEUE_DEPTH"), out v))
+            opts.MaxQueueDepth = v;
+        if (int.TryParse(Environment.GetEnvironmentVariable("CONFIG_CACHE_TTL_MINUTES"), out v))
+            opts.ConfigCacheTtl = TimeSpan.FromMinutes(v);
+    }
+}

--- a/template/netwrix-csharp/ConnectorFramework/FunctionContext.cs
+++ b/template/netwrix-csharp/ConnectorFramework/FunctionContext.cs
@@ -8,7 +8,7 @@ namespace Netwrix.ConnectorFramework;
 /// Per-request context provided to every connector operation.
 /// Injected by the framework via DI (Scoped lifetime).
 /// </summary>
-public sealed class FunctionContext : IScanWriter, IScanProgress, IAsyncDisposable
+public sealed class FunctionContext : IFunctionContext, IScanWriter, IScanProgress, IAsyncDisposable
 {
     private static readonly ActivitySource ActivitySource = new("Netwrix.ConnectorFramework");
 

--- a/template/netwrix-csharp/ConnectorFramework/IFunctionContext.cs
+++ b/template/netwrix-csharp/ConnectorFramework/IFunctionContext.cs
@@ -1,0 +1,30 @@
+using System.Diagnostics;
+
+namespace Netwrix.ConnectorFramework;
+
+/// <summary>
+/// Per-request context provided to every connector operation.
+/// Implement <see cref="FunctionContext"/> in production; use a test double in unit tests.
+/// </summary>
+public interface IFunctionContext
+{
+    ExecutionContext Execution { get; }
+    ILogger Log { get; }
+    IReadOnlyDictionary<string, string> Secrets { get; }
+    ConnectorRequestData Request { get; }
+
+    Activity? StartActivity(string name);
+    BatchManager GetTable(string tableName);
+
+    Task UpdateExecutionAsync(
+        string? status = null,
+        int? totalObjects = null,
+        int? completedObjects = null,
+        DateTimeOffset? completedAt = null,
+        int incrementCompletedObjects = 0,
+        CancellationToken ct = default);
+
+    Task<Dictionary<string, string>?> GetConnectorStateAsync(CancellationToken ct = default);
+    Task SetConnectorStateAsync(Dictionary<string, object?> data, CancellationToken ct = default);
+    Task FlushTablesAsync(CancellationToken ct = default);
+}

--- a/template/netwrix-csharp/ConnectorFramework/ScanStatusMessage.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ScanStatusMessage.cs
@@ -1,0 +1,31 @@
+using System.Text.Json.Serialization;
+
+namespace Netwrix.ConnectorFramework;
+
+/// <summary>
+/// Schema for entries written to the <c>scan:status:{executionId}</c> Redis stream.
+/// Serialized as a single <c>data</c> field in each stream entry.
+/// </summary>
+public sealed record ScanStatusMessage
+{
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("scan_execution_id")]
+    public required string ScanExecutionId { get; init; }
+
+    [JsonPropertyName("timestamp")]
+    public required DateTimeOffset Timestamp { get; init; }
+
+    [JsonPropertyName("message")]
+    public string Message { get; init; } = string.Empty;
+
+    [JsonPropertyName("partial_data")]
+    public bool PartialData { get; init; }
+
+    [JsonPropertyName("objects_count")]
+    public int ObjectsCount { get; init; }
+
+    [JsonPropertyName("failed_paths_count")]
+    public int FailedPathsCount { get; init; }
+}


### PR DESCRIPTION
## Summary

Eliminates `IgnoresAccessChecksTo` from connector test projects entirely by restructuring how framework internals are accessed in tests. Two complementary changes:

**1. `ConnectorFramework.Testing` — new test-helper assembly**

A new project with `InternalsVisibleTo` access to `ConnectorFramework` that exposes a single public extension method:

```csharp
services.AddConnectorFrameworkTestServices();
```

This replaces the boilerplate block of 10+ manual service registrations (for `RequestDataHolder`, `FunctionContext`, `AACorePlatformFacade`, etc.) that connector test projects previously had to duplicate — and which required `IgnoresAccessChecksTo` to compile.

**2. `ConnectorFramework.Tests` — framework-owned tests moved here**

Tests that were living in connector test projects but test pure framework behaviour (not connector logic) are now in the framework's own test project where they belong:

- `OrchestratorOptionsTests` — tests `ApplyOrchestratorEnvVarOverrides` (was duplicated in both SPO and EntraID connector tests)
- `CrawlRunOrchestratorRedisIntegrationTests` — end-to-end stop/pause-resume tests against real Redis (Testcontainers); previously in SPO tests as `PauseResumeIntegrationTests` which needed `IgnoresAccessChecksTo` to access `AA26CrawlRunSignalSource`
- `CrawlRunOrchestratorIntegrationTests` — additional orchestrator integration tests

**3. `CrawlRunOrchestratorServiceExtensions` — shared env-var override logic**

`ApplyOrchestratorEnvVarOverrides` was copied verbatim in every connector's `ServiceCollectionExtensions.cs`. It is now a public static method in the framework that connectors delegate to:

```csharp
.PostConfigure(CrawlRunOrchestratorServiceExtensions.ApplyOrchestratorEnvVarOverrides);
```

**4. `FunctionContext.LoadSecrets` — honours `SECRETS_BASE_PATH`**

When `SECRETS_BASE_PATH` is set (as tests do), secrets are loaded from that directory instead of the hardcoded `/var/secrets`. This makes `RunScanExitReasonTests` work on developer machines without requiring real mounted secrets.

---

### Result

Adding a new connector test project now requires:
1. Add `ProjectReference` to `ConnectorFramework.Testing`
2. Call `services.AddConnectorFrameworkTestServices()` in any test that bootstraps the handler

No framework template change required — ever.

See companion PR in dspm-connectors (`feature/434019-csharp-tests`) which removes `IgnoresAccessChecksTo` and `ConnectorFrameworkAccess.cs` from `SharepointOnline.AccessScan.Tests` and `EntraId.Sync.Tests`.

## Test plan

- [x] `dotnet build ConnectorFramework.csproj` — 0 errors, 0 warnings
- [x] `dotnet build ConnectorFramework.Testing.csproj` — 0 errors, 0 warnings
- [x] `dotnet build ConnectorFramework.Tests.csproj` — 0 errors, 0 warnings
- [x] `dotnet test ConnectorFramework.Tests.csproj --filter "Category!=Integration"` — all unit tests pass
- [x] `dotnet test ConnectorFramework.Tests.csproj` — integration tests pass (requires Docker/Redis)
- [x] `make templates-update` in dspm-connectors propagates all new files
- [x] `SharepointOnline.AccessScan.Tests` builds and all tests pass with no `IgnoresAccessChecksTo`
- [x] `EntraId.Sync.Tests` builds and all tests pass with no `IgnoresAccessChecksTo`
- [x] `grep -r "IgnoresAccessChecksTo" connectors/` returns no output

AB#433121