### PR TITLE
AB#432092 — [SPO Access scan] Permission set records not flushed incrementally

### DIFF
--- a/template/netwrix-csharp/ConnectorFramework.Testing/ConnectorFrameworkTestServiceExtensions.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Testing/ConnectorFrameworkTestServiceExtensions.cs
@@ -49,6 +49,7 @@ public static class ConnectorFrameworkTestServiceExtensions
         services.AddScoped<AACrawlTaskCorePlatformFacade>(sp =>
             new AACrawlTaskCorePlatformFacade(
                 sp.GetRequiredService<AACorePlatformFacade>(),
+                sp.GetRequiredService<IScanWriter>(),
                 sp.GetRequiredService<IScanProgress>(),
                 sp.GetRequiredService<ILoggerFactory>()
                     .CreateLogger<AACrawlTaskCorePlatformFacade>()));

--- a/template/netwrix-csharp/ConnectorFramework.Tests/AACrawlTaskCorePlatformFacadeTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/AACrawlTaskCorePlatformFacadeTests.cs
@@ -40,9 +40,11 @@ public class AACrawlTaskCorePlatformFacadeTests
 
     private static AACrawlTaskCorePlatformFacade CreateFacade(
         AACorePlatformFacade? core = null,
+        IScanWriter? writer = null,
         IScanProgress? progress = null)
         => new(
             core ?? CreateCore(),
+            writer ?? WriterMock().Object,
             progress ?? ProgressMock().Object,
             NullLogger<AACrawlTaskCorePlatformFacade>.Instance);
 
@@ -117,6 +119,30 @@ public class AACrawlTaskCorePlatformFacadeTests
             null,
             15,
             It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EnsureRegularTaskProgressUpdate_AboveThreshold_FlushesBuffers()
+    {
+        var writerMock = WriterMock();
+        var facade = CreateFacade(writer: writerMock.Object);
+        SimulateElapsedMinutes(facade, 6);
+
+        await facade.EnsureRegularTaskProgressUpdate(Guid.NewGuid(), new CrawlResponse { ProcessedItemCount = 5 });
+
+        writerMock.Verify(w => w.FlushBuffers(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EnsureRegularTaskProgressUpdate_BelowThreshold_DoesNotFlushBuffers()
+    {
+        var writerMock = WriterMock();
+        var facade = CreateFacade(writer: writerMock.Object);
+        // Default _lastUpdateTimestamp is Stopwatch.GetTimestamp() — elapsed is ~0 minutes
+
+        await facade.EnsureRegularTaskProgressUpdate(Guid.NewGuid(), new CrawlResponse { ProcessedItemCount = 5 });
+
+        writerMock.Verify(w => w.FlushBuffers(It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ── FinalizeScan ─────────────────────────────────────────────────────────

--- a/template/netwrix-csharp/ConnectorFramework/AACrawlTaskCorePlatformFacade.cs
+++ b/template/netwrix-csharp/ConnectorFramework/AACrawlTaskCorePlatformFacade.cs
@@ -15,6 +15,7 @@ public sealed class AACrawlTaskCorePlatformFacade : ICorePlatformFacade, ICrawlT
     private const int MaxUpdateIntervalMinutes = 5;
 
     private readonly AACorePlatformFacade _core;
+    private readonly IScanWriter _writer;
     private readonly IScanProgress _progress;
     private readonly ILogger<AACrawlTaskCorePlatformFacade> _logger;
 
@@ -33,13 +34,16 @@ public sealed class AACrawlTaskCorePlatformFacade : ICorePlatformFacade, ICrawlT
 
     public AACrawlTaskCorePlatformFacade(
         AACorePlatformFacade core,
+        IScanWriter writer,
         IScanProgress progress,
         ILogger<AACrawlTaskCorePlatformFacade> logger)
     {
         ArgumentNullException.ThrowIfNull(core);
+        ArgumentNullException.ThrowIfNull(writer);
         ArgumentNullException.ThrowIfNull(progress);
         ArgumentNullException.ThrowIfNull(logger);
         _core = core;
+        _writer = writer;
         _progress = progress;
         _logger = logger;
     }
@@ -123,6 +127,15 @@ public sealed class AACrawlTaskCorePlatformFacade : ICorePlatformFacade, ICrawlT
 
         try
         {
+            try
+            {
+                _writer.FlushBuffers(CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unable to flush buffers during regular task update for task {TaskReference}", taskReference);
+            }
+
             using var activity = _progress.StartActivity("update-execution-progress");
             var totalItems = _processedItems.Values.Sum();
             var delta = totalItems - _reportedItemsCount;

--- a/template/netwrix-csharp/ConnectorFramework/CrawlRunOrchestratorServiceExtensions.cs
+++ b/template/netwrix-csharp/ConnectorFramework/CrawlRunOrchestratorServiceExtensions.cs
@@ -16,18 +16,38 @@ public static class CrawlRunOrchestratorServiceExtensions
     public static void ApplyOrchestratorEnvVarOverrides(CrawlRunOrchestratorOptions opts)
     {
         if (int.TryParse(Environment.GetEnvironmentVariable("MAX_WORKERS"), out var v))
+        {
             opts.MaxWorkers = v;
+        }
+
         if (int.TryParse(Environment.GetEnvironmentVariable("MAX_CONCURRENCY_PER_SOURCE"), out v))
+        {
             opts.MaxConcurrencyPerSource = v;
+        }
+
         if (int.TryParse(Environment.GetEnvironmentVariable("MAX_ATTEMPTS"), out v))
+        {
             opts.MaxAttempts = v;
+        }
+
         if (int.TryParse(Environment.GetEnvironmentVariable("MAX_AUTH_RETRY_ATTEMPTS"), out v))
+        {
             opts.MaxAuthRetryAttempts = v;
+        }
+
         if (int.TryParse(Environment.GetEnvironmentVariable("MAX_HASH_MISMATCH_ATTEMPTS"), out v))
+        {
             opts.MaxHashMismatchAttempts = v;
+        }
+
         if (int.TryParse(Environment.GetEnvironmentVariable("MAX_QUEUE_DEPTH"), out v))
+        {
             opts.MaxQueueDepth = v;
+        }
+
         if (int.TryParse(Environment.GetEnvironmentVariable("CONFIG_CACHE_TTL_MINUTES"), out v))
+        {
             opts.ConfigCacheTtl = TimeSpan.FromMinutes(v);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `AACrawlTaskCorePlatformFacade` was reporting per-page progress to the platform but never draining `BatchManager` buffers. Sparse tables (e.g. `permission_sets`) never hit the 500 KB auto-flush threshold mid-task, so their data was invisible in ClickHouse until task completion — potentially hours into a large SPO list scan.
- Inject `IScanWriter` into `AACrawlTaskCorePlatformFacade` and call `FlushBuffers` inside the throttle-gated block in `EnsureRegularTaskProgressUpdate`, **before** `UpdateExecutionAsync`, so ClickHouse receives data before the platform is told items are processed.
- Flush failures are caught and logged independently with a distinct message so they do not swallow or misattribute `UpdateExecutionAsync` errors.
- Also fixes pre-existing brace-style format violations (`IDE0011`) in `CrawlRunOrchestratorServiceExtensions` that landed on `main` in the prior merge.

## Test plan

- [ ] New unit tests: `EnsureRegularTaskProgressUpdate_AboveThreshold_FlushesBuffers` and `EnsureRegularTaskProgressUpdate_BelowThreshold_DoesNotFlushBuffers` pass
- [ ] All 174 existing tests still pass (verified locally)
- [ ] Run `make templates-update` in `dspm-connectors` to propagate to all 8 connector vendored copies
- [ ] Integration: trigger a large SPO list scan and confirm `permission_sets` rows appear in ClickHouse mid-scan rather than only at task completion

AB#432092

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>