### PR TITLE
chore: bump OTEL version to 1.15.3

### DIFF
--- a/template/netwrix-csharp/ConnectorFramework/ConnectorFramework.csproj
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorFramework.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="Netwrix.Overlord.Sdk.Orchestration" Version="2.0.0.14-preview" />
     <PackageReference Include="Netwrix.UK.Core" Version="5.2.2.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.*" />
-    <PackageReference Include="OpenTelemetry" Version="1.9.*" />
+    <PackageReference Include="OpenTelemetry" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.*" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.*" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.*" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.*" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.*" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.*" />
     <!-- Pin to 9.0.x so ConnectorFramework.deps.json satisfies connectors that require System.Text.Json 9.0.0.0 -->


### PR DESCRIPTION
- Bump OTEL version which dependabot missed: https://github.com/netwrix/dspm-connector-templates/security/dependabot/25