### PR TITLE
Update versions for SDK to 2.0.0.19-preview in ConnectorFramework.Testing.csproj

### DIFF
--- a/template/netwrix-csharp/ConnectorFramework.Testing/ConnectorFramework.Testing.csproj
+++ b/template/netwrix-csharp/ConnectorFramework.Testing/ConnectorFramework.Testing.csproj
@@ -17,9 +17,9 @@
 
   <!-- Explicit SDK refs so connector test consumers can reference their types without indirect deps -->
   <ItemGroup>
-    <PackageReference Include="Netwrix.Overlord.Sdk.Cloud" Version="2.0.0.14-preview" />
-    <PackageReference Include="Netwrix.Overlord.Sdk.Core" Version="2.0.0.14-preview" />
-    <PackageReference Include="Netwrix.Overlord.Sdk.Orchestration" Version="2.0.0.14-preview" />
+    <PackageReference Include="Netwrix.Overlord.Sdk.Cloud" Version="2.0.0.19-preview" />
+    <PackageReference Include="Netwrix.Overlord.Sdk.Core" Version="2.0.0.19-preview" />
+    <PackageReference Include="Netwrix.Overlord.Sdk.Orchestration" Version="2.0.0.19-preview" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.*" />
   </ItemGroup>
 


### PR DESCRIPTION
The versions for the SDK imports are 2.0.0.14 which cause an error on restore when this version is restored to a project with different versions. This is inconsistent with the other versions in the repo causing errors restoring nuget packages.