### PR TITLE
Register orchestration OTel meter and remove duplicate metrics

### DIFF
--- a/template/netwrix-csharp/ConnectorFramework/AACrawlTaskCorePlatformFacade.cs
+++ b/template/netwrix-csharp/ConnectorFramework/AACrawlTaskCorePlatformFacade.cs
@@ -22,7 +22,6 @@ public sealed class AACrawlTaskCorePlatformFacade : ICorePlatformFacade, ICrawlT
 
     private readonly ConcurrentDictionary<Guid, int> _processedItems = new();
     private readonly ConcurrentDictionary<Guid, int> _processedErrors = new();
-    private readonly ConcurrentDictionary<Guid, long> _taskStartTimestamps = new();
     private int _reportedItemsCount;
     private int _totalErrors;
     private long _lastUpdateTimestamp = Stopwatch.GetTimestamp();
@@ -90,10 +89,10 @@ public sealed class AACrawlTaskCorePlatformFacade : ICorePlatformFacade, ICrawlT
     }
 
     /// <summary>
-    /// Returns the <see cref="CrawlTaskConfiguration"/> for the given task reference,
-    /// records a start timestamp for duration tracking, and increments the tasks-started metric.
+    /// Returns the <see cref="CrawlTaskConfiguration"/> for the given task reference
+    /// and increments the tasks-started metric.
     /// </summary>
-    /// <param name="crawlTaskReference">Unique identifier for this task; used to key the start timestamp.</param>
+    /// <param name="crawlTaskReference">Unique identifier for this task.</param>
     /// <param name="startDate">Scheduled start date for the task (unused; present for interface compatibility).</param>
     public Task<CrawlTaskConfiguration> StartTask(Guid crawlTaskReference, DateTimeOffset startDate)
     {
@@ -102,7 +101,6 @@ public sealed class AACrawlTaskCorePlatformFacade : ICorePlatformFacade, ICrawlT
             throw new InvalidOperationException("Initialize() must be called before StartTask.");
         }
 
-        _taskStartTimestamps[crawlTaskReference] = Stopwatch.GetTimestamp();
         ConnectorMetrics.TasksStarted.Add(1);
 
         return Task.FromResult(new CrawlTaskConfiguration
@@ -176,8 +174,8 @@ public sealed class AACrawlTaskCorePlatformFacade : ICorePlatformFacade, ICrawlT
     }
 
     /// <summary>
-    /// Records task completion: updates per-task item and error counts, records task duration
-    /// and emits the tasks-completed metric, accumulates errors into the scan-level total,
+    /// Records task completion: updates per-task item and error counts, emits the
+    /// tasks-completed metric, accumulates errors into the scan-level total,
     /// and removes the task's entries to prevent unbounded memory growth.
     /// </summary>
     /// <param name="taskProgress">Final progress report from the orchestrator for this task.</param>
@@ -193,11 +191,6 @@ public sealed class AACrawlTaskCorePlatformFacade : ICorePlatformFacade, ICrawlT
             taskProgress.ProcessedItemCount,
             (_, _) => taskProgress.ProcessedItemCount);
 
-        // Record duration and completion for all tasks, including leaf tasks (ChildTasks is null).
-        if (_taskStartTimestamps.TryRemove(taskProgress.CrawlTaskReference, out var startTimestamp))
-        {
-            ConnectorMetrics.TaskDuration.Record(Stopwatch.GetElapsedTime(startTimestamp).TotalSeconds);
-        }
         ConnectorMetrics.TasksCompleted.Add(1);
 
         // Accumulate errors into the scan-level total before removing the per-task entry.
@@ -227,7 +220,9 @@ public sealed class AACrawlTaskCorePlatformFacade : ICorePlatformFacade, ICrawlT
     public async Task<string> FinalizeScan()
     {
         if (_crawlRunRequest is null)
+        {
             throw new InvalidOperationException("Initialize() must be called before FinalizeScan.");
+        }
 
         using var activity = _progress.StartActivity("finalize-scan");
         var totalItems = _processedItems.Values.Sum();

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorMetrics.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorMetrics.cs
@@ -27,23 +27,6 @@ internal static class ConnectorMetrics
         "connector.tasks.completed",
         description: "Number of crawl tasks finalised within a scan execution");
 
-    /// <summary>
-    /// Wall-clock duration of individual crawl tasks in seconds.
-    /// Measured from StartTask() to FinaliseTask() for the same task reference.
-    /// </summary>
-    public static readonly Histogram<double> TaskDuration = Meter.CreateHistogram<double>(
-        "connector.task.duration",
-        unit: "s",
-        description: "Wall-clock duration of individual crawl tasks in seconds");
-
-    /// <summary>
-    /// Number of crawl tasks that permanently failed after exhausting all retry attempts.
-    /// Emitted by CrawlRunOrchestrator on the same meter when Module B orchestration is active.
-    /// </summary>
-    public static readonly Counter<long> TasksDeadLettered = Meter.CreateCounter<long>(
-        "connector.tasks.dead_lettered",
-        description: "Number of crawl tasks that permanently failed after exhausting all retry attempts");
-
     // ── Source rate limiting ──────────────────────────────────────────────────
 
     /// <summary>

--- a/template/netwrix-csharp/ConnectorFramework/Program.cs
+++ b/template/netwrix-csharp/ConnectorFramework/Program.cs
@@ -444,6 +444,7 @@ internal static class Program
             {
                 metrics.SetResourceBuilder(resourceBuilder)
                     .AddMeter(ConnectorMetrics.MeterName)
+                    .AddMeter("Netwrix.Overlord.Sdk.Orchestration") // CrawlRunOrchestratorMetrics.MeterName — use type constant once Sdk.Orchestration package is bumped
                     .AddHttpClientInstrumentation();
 
                 if (isHttpMode)


### PR DESCRIPTION
## Summary

- Adds `.AddMeter(\"Netwrix.Overlord.Sdk.Orchestration\")` to the OTel metrics pipeline so orchestration metrics (`connector.tasks.dispatch_attempts`, `connector.task.duration`, `connector.tasks.dead_lettered`, `connector.tasks.queue_depth_exceeded`) are exported to Prometheus. Previously silently dropped.
- Removes `ConnectorMetrics.TaskDuration` — duplicate of `connector.task.duration` already recorded by `CrawlRunOrchestrationFacade` under the orchestration meter. Both facades are in the same call chain, producing double data points for every task.
- Removes `ConnectorMetrics.TasksDeadLettered` — dead code declared in `ConnectorMetrics` but never incremented from ConnectorFramework. Actual emission is in `CrawlRunOrchestrator` under the orchestration meter.
- Removes `_taskStartTimestamps` dictionary and all Stopwatch tracking from `AACrawlTaskCorePlatformFacade` — no longer needed now that task duration is owned by the orchestration layer.

## Notes

- The `AddMeter` call uses a string literal `"Netwrix.Overlord.Sdk.Orchestration"` instead of `CrawlRunOrchestratorMetrics.MeterName` because `CrawlRunOrchestratorMetrics` was added in a `platform-1secure` branch (`bug/435934`) that has not yet been published as a new NuGet package. A follow-up is to bump the `Netwrix.Overlord.Sdk.Orchestration` package version and switch to the type constant once published.
- `connector.tasks.started` and `connector.tasks.completed` in `ConnectorMetrics` are intentionally kept — they measure distinct things from the orchestration counters.

## Test plan

- [ ] Build passes: `dotnet build dspm-connector-templates.sln`
- [ ] 185 unit tests pass: `dotnet test dspm-connector-templates.sln --filter "FullyQualifiedName!~Integration"`
- [ ] `dotnet format style` and `dotnet format analyzers` clean on `ConnectorFramework.csproj`
- [ ] After merge, run `make templates-update` in `dspm-connectors` to propagate to all vendored connector copies

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>