### PR TITLE
AB#435934 — Map BrokenCircuitException to InfrastructureUnavailableException in ConnectorFramework

### DIFF
--- a/template/netwrix-csharp/ConnectorFramework.Testing/ConnectorFramework.Testing.csproj
+++ b/template/netwrix-csharp/ConnectorFramework.Testing/ConnectorFramework.Testing.csproj
@@ -17,9 +17,9 @@
 
   <!-- Explicit SDK refs so connector test consumers can reference their types without indirect deps -->
   <ItemGroup>
-    <PackageReference Include="Netwrix.Overlord.Sdk.Cloud" Version="2.0.0.19-preview" />
-    <PackageReference Include="Netwrix.Overlord.Sdk.Core" Version="2.0.0.19-preview" />
-    <PackageReference Include="Netwrix.Overlord.Sdk.Orchestration" Version="2.0.0.19-preview" />
+    <PackageReference Include="Netwrix.Overlord.Sdk.Cloud" Version="2.0.0.25-preview" />
+    <PackageReference Include="Netwrix.Overlord.Sdk.Core" Version="2.0.0.25-preview" />
+    <PackageReference Include="Netwrix.Overlord.Sdk.Orchestration" Version="2.0.0.25-preview" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.*" />
   </ItemGroup>
 

--- a/template/netwrix-csharp/ConnectorFramework.Tests/BatchManagerTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/BatchManagerTests.cs
@@ -2,6 +2,8 @@ using System.Net;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Moq.Protected;
+using Netwrix.Overlord.Sdk.Core.Exceptions;
+using Polly.CircuitBreaker;
 using Xunit;
 
 namespace Netwrix.ConnectorFramework.Tests;
@@ -191,6 +193,69 @@ public class BatchManagerTests
         await bm.FlushAsync();
 
         Assert.Equal(2, flushedCount);
+    }
+
+    [Fact]
+    public async Task FlushAsync_BrokenCircuit_ThrowsInfrastructureUnavailable()
+    {
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new BrokenCircuitException("circuit open"));
+
+        var httpClient = new HttpClient(handlerMock.Object);
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        var bm = new BatchManager("test_table", factoryMock.Object, MakeRequest(), NullLogger<BatchManager>.Instance);
+        bm.AddObject(new { x = 1 });
+
+        var ex = await Assert.ThrowsAsync<InfrastructureUnavailableException>(() => bm.FlushAsync());
+        Assert.Contains("data-ingestion", ex.Message);
+        // bm intentionally not disposed: FlushAsync already completed the channel and
+        // _flushWorker is faulted — DisposeAsync would re-throw the same exception.
+    }
+
+    [Fact]
+    public async Task FlushAsync_IsolatedCircuit_ThrowsInfrastructureUnavailable()
+    {
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new IsolatedCircuitException("circuit isolated"));
+
+        var httpClient = new HttpClient(handlerMock.Object);
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        var bm = new BatchManager("test_table", factoryMock.Object, MakeRequest(), NullLogger<BatchManager>.Instance);
+        bm.AddObject(new { x = 1 });
+
+        await Assert.ThrowsAsync<InfrastructureUnavailableException>(() => bm.FlushAsync());
+    }
+
+    [Fact]
+    public async Task FlushAsync_GenericHttpException_IsSwallowed()
+    {
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("connection refused"));
+
+        var httpClient = new HttpClient(handlerMock.Object);
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        await using var bm = new BatchManager("test_table", factoryMock.Object, MakeRequest(), NullLogger<BatchManager>.Instance);
+        bm.AddObject(new { x = 1 });
+
+        await bm.FlushAsync(); // should not throw
     }
 
     [Fact]

--- a/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorFramework.Tests.csproj
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorFramework.Tests.csproj
@@ -27,9 +27,9 @@
     <ProjectReference Include="..\ConnectorFramework\ConnectorFramework.csproj" />
     <!-- Sdk.Cloud/Core/Orchestration come transitively via ConnectorFramework but listed
          explicitly so test code can reference their types without an indirect dependency. -->
-    <PackageReference Include="Netwrix.Overlord.Sdk.Cloud" Version="2.0.0.19-preview" />
+    <PackageReference Include="Netwrix.Overlord.Sdk.Cloud" Version="2.0.0.25-preview" />
     <PackageReference Include="Netwrix.Overlord.Sdk.Core" Version="2.0.0.25-preview" />
-    <PackageReference Include="Netwrix.Overlord.Sdk.Orchestration" Version="2.0.0.19-preview" />
+    <PackageReference Include="Netwrix.Overlord.Sdk.Orchestration" Version="2.0.0.25-preview" />
     <PackageReference Include="Microsoft.Extensions.Resilience" Version="8.*" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.*" />
     <PackageReference Include="Testcontainers.Redis" Version="3.*" />

--- a/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorFramework.Tests.csproj
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorFramework.Tests.csproj
@@ -28,7 +28,7 @@
     <!-- Sdk.Cloud/Core/Orchestration come transitively via ConnectorFramework but listed
          explicitly so test code can reference their types without an indirect dependency. -->
     <PackageReference Include="Netwrix.Overlord.Sdk.Cloud" Version="2.0.0.19-preview" />
-    <PackageReference Include="Netwrix.Overlord.Sdk.Core" Version="2.0.0.19-preview" />
+    <PackageReference Include="Netwrix.Overlord.Sdk.Core" Version="2.0.0.25-preview" />
     <PackageReference Include="Netwrix.Overlord.Sdk.Orchestration" Version="2.0.0.19-preview" />
     <PackageReference Include="Microsoft.Extensions.Resilience" Version="8.*" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.*" />

--- a/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateClientTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateClientTests.cs
@@ -1,0 +1,66 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Moq.Protected;
+using Netwrix.Overlord.Sdk.Core.Exceptions;
+using Polly.CircuitBreaker;
+using Xunit;
+
+namespace Netwrix.ConnectorFramework.Tests;
+
+public class ConnectorStateClientTests
+{
+    private static ConnectorStateClient CreateClientThrowing(Exception ex)
+    {
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(ex);
+        return new ConnectorStateClient(
+            new HttpClient(handlerMock.Object) { BaseAddress = new Uri("http://connector-state/") },
+            NullLogger<ConnectorStateClient>.Instance);
+    }
+
+    [Fact]
+    public async Task GetStateAsync_BrokenCircuit_ThrowsInfrastructureUnavailable()
+    {
+        var client = CreateClientThrowing(new BrokenCircuitException("circuit open"));
+
+        var ex = await Assert.ThrowsAsync<InfrastructureUnavailableException>(
+            () => client.GetStateAsync("scan-1", null, CancellationToken.None));
+
+        Assert.Contains("connector-state", ex.Message);
+    }
+
+    [Fact]
+    public async Task GetStateAsync_IsolatedCircuit_ThrowsInfrastructureUnavailable()
+    {
+        var client = CreateClientThrowing(new IsolatedCircuitException("circuit isolated"));
+
+        await Assert.ThrowsAsync<InfrastructureUnavailableException>(
+            () => client.GetStateAsync("scan-1", null, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task PostStateAsync_BrokenCircuit_ThrowsInfrastructureUnavailable()
+    {
+        var client = CreateClientThrowing(new BrokenCircuitException("circuit open"));
+
+        var ex = await Assert.ThrowsAsync<InfrastructureUnavailableException>(
+            () => client.PostStateAsync("scan-1", null, new Dictionary<string, string>(), CancellationToken.None));
+
+        Assert.Contains("connector-state", ex.Message);
+    }
+
+    [Fact]
+    public async Task DeleteManyAsync_BrokenCircuit_ThrowsInfrastructureUnavailable()
+    {
+        var client = CreateClientThrowing(new BrokenCircuitException("circuit open"));
+
+        var ex = await Assert.ThrowsAsync<InfrastructureUnavailableException>(
+            () => client.DeleteManyAsync("scan-1", null, ["key1"], CancellationToken.None));
+
+        Assert.Contains("connector-state", ex.Message);
+    }
+}

--- a/template/netwrix-csharp/ConnectorFramework/AACrawlTaskCorePlatformFacade.cs
+++ b/template/netwrix-csharp/ConnectorFramework/AACrawlTaskCorePlatformFacade.cs
@@ -22,7 +22,6 @@ public sealed class AACrawlTaskCorePlatformFacade : ICorePlatformFacade, ICrawlT
 
     private readonly ConcurrentDictionary<Guid, int> _processedItems = new();
     private readonly ConcurrentDictionary<Guid, int> _processedErrors = new();
-    private readonly ConcurrentDictionary<Guid, long> _taskStartTimestamps = new();
     private int _reportedItemsCount;
     private int _totalErrors;
     private long _lastUpdateTimestamp = Stopwatch.GetTimestamp();
@@ -90,10 +89,10 @@ public sealed class AACrawlTaskCorePlatformFacade : ICorePlatformFacade, ICrawlT
     }
 
     /// <summary>
-    /// Returns the <see cref="CrawlTaskConfiguration"/> for the given task reference,
-    /// records a start timestamp for duration tracking, and increments the tasks-started metric.
+    /// Returns the <see cref="CrawlTaskConfiguration"/> for the given task reference
+    /// and increments the tasks-started metric.
     /// </summary>
-    /// <param name="crawlTaskReference">Unique identifier for this task; used to key the start timestamp.</param>
+    /// <param name="crawlTaskReference">Unique identifier for this task.</param>
     /// <param name="startDate">Scheduled start date for the task (unused; present for interface compatibility).</param>
     public Task<CrawlTaskConfiguration> StartTask(Guid crawlTaskReference, DateTimeOffset startDate)
     {
@@ -102,7 +101,6 @@ public sealed class AACrawlTaskCorePlatformFacade : ICorePlatformFacade, ICrawlT
             throw new InvalidOperationException("Initialize() must be called before StartTask.");
         }
 
-        _taskStartTimestamps[crawlTaskReference] = Stopwatch.GetTimestamp();
         ConnectorMetrics.TasksStarted.Add(1);
 
         return Task.FromResult(new CrawlTaskConfiguration
@@ -176,8 +174,8 @@ public sealed class AACrawlTaskCorePlatformFacade : ICorePlatformFacade, ICrawlT
     }
 
     /// <summary>
-    /// Records task completion: updates per-task item and error counts, records task duration
-    /// and emits the tasks-completed metric, accumulates errors into the scan-level total,
+    /// Records task completion: updates per-task item and error counts, emits the
+    /// tasks-completed metric, accumulates errors into the scan-level total,
     /// and removes the task's entries to prevent unbounded memory growth.
     /// </summary>
     /// <param name="taskProgress">Final progress report from the orchestrator for this task.</param>
@@ -193,11 +191,6 @@ public sealed class AACrawlTaskCorePlatformFacade : ICorePlatformFacade, ICrawlT
             taskProgress.ProcessedItemCount,
             (_, _) => taskProgress.ProcessedItemCount);
 
-        // Record duration and completion for all tasks, including leaf tasks (ChildTasks is null).
-        if (_taskStartTimestamps.TryRemove(taskProgress.CrawlTaskReference, out var startTimestamp))
-        {
-            ConnectorMetrics.TaskDuration.Record(Stopwatch.GetElapsedTime(startTimestamp).TotalSeconds);
-        }
         ConnectorMetrics.TasksCompleted.Add(1);
 
         // Accumulate errors into the scan-level total before removing the per-task entry.
@@ -227,7 +220,9 @@ public sealed class AACrawlTaskCorePlatformFacade : ICorePlatformFacade, ICrawlT
     public async Task<string> FinalizeScan()
     {
         if (_crawlRunRequest is null)
+        {
             throw new InvalidOperationException("Initialize() must be called before FinalizeScan.");
+        }
 
         using var activity = _progress.StartActivity("finalize-scan");
         var totalItems = _processedItems.Values.Sum();

--- a/template/netwrix-csharp/ConnectorFramework/BatchManager.cs
+++ b/template/netwrix-csharp/ConnectorFramework/BatchManager.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 using System.Threading.Channels;
+using Netwrix.Overlord.Sdk.Core.Exceptions;
+using Polly.CircuitBreaker;
 
 namespace Netwrix.ConnectorFramework;
 
@@ -231,6 +233,10 @@ public sealed class BatchManager : IAsyncDisposable
             {
                 _logger.LogError("Batch flush returned {StatusCode} for table {Table}", (int)response.StatusCode, _tableName);
             }
+        }
+        catch (BrokenCircuitException ex)
+        {
+            throw new InfrastructureUnavailableException("data-ingestion", ex);
         }
         catch (Exception ex)
         {

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorFramework.csproj
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorFramework.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Netwrix.Overlord.Sdk.Cloud" Version="2.0.0.19-preview" />
+    <PackageReference Include="Netwrix.Overlord.Sdk.Cloud" Version="2.0.0.25-preview" />
     <PackageReference Include="Netwrix.Overlord.Sdk.Core" Version="2.0.0.25-preview" />
-    <PackageReference Include="Netwrix.Overlord.Sdk.Orchestration" Version="2.0.0.19-preview" />
+    <PackageReference Include="Netwrix.Overlord.Sdk.Orchestration" Version="2.0.0.25-preview" />
     <PackageReference Include="Netwrix.UK.Core" Version="5.2.2.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.*" />
     <PackageReference Include="OpenTelemetry" Version="1.15.*" />

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorFramework.csproj
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorFramework.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="Netwrix.Overlord.Sdk.Cloud" Version="2.0.0.19-preview" />
-    <PackageReference Include="Netwrix.Overlord.Sdk.Core" Version="2.0.0.19-preview" />
+    <PackageReference Include="Netwrix.Overlord.Sdk.Core" Version="2.0.0.25-preview" />
     <PackageReference Include="Netwrix.Overlord.Sdk.Orchestration" Version="2.0.0.19-preview" />
     <PackageReference Include="Netwrix.UK.Core" Version="5.2.2.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.*" />

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorMetrics.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorMetrics.cs
@@ -27,23 +27,6 @@ internal static class ConnectorMetrics
         "connector.tasks.completed",
         description: "Number of crawl tasks finalised within a scan execution");
 
-    /// <summary>
-    /// Wall-clock duration of individual crawl tasks in seconds.
-    /// Measured from StartTask() to FinaliseTask() for the same task reference.
-    /// </summary>
-    public static readonly Histogram<double> TaskDuration = Meter.CreateHistogram<double>(
-        "connector.task.duration",
-        unit: "s",
-        description: "Wall-clock duration of individual crawl tasks in seconds");
-
-    /// <summary>
-    /// Number of crawl tasks that permanently failed after exhausting all retry attempts.
-    /// Emitted by CrawlRunOrchestrator on the same meter when Module B orchestration is active.
-    /// </summary>
-    public static readonly Counter<long> TasksDeadLettered = Meter.CreateCounter<long>(
-        "connector.tasks.dead_lettered",
-        description: "Number of crawl tasks that permanently failed after exhausting all retry attempts");
-
     // ── Source rate limiting ──────────────────────────────────────────────────
 
     /// <summary>

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorStateClient.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorStateClient.cs
@@ -1,7 +1,9 @@
 using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
+using Netwrix.Overlord.Sdk.Core.Exceptions;
 using Netwrix.Overlord.Sdk.Core.Storage.Exceptions;
+using Polly.CircuitBreaker;
 
 namespace Netwrix.ConnectorFramework;
 
@@ -113,6 +115,10 @@ public sealed class ConnectorStateClient
         {
             throw;
         }
+        catch (BrokenCircuitException ex)
+        {
+            throw new InfrastructureUnavailableException("connector-state", ex);
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "connector-state GET failed for scan {ScanId}", scanId);
@@ -168,6 +174,10 @@ public sealed class ConnectorStateClient
         catch (StateStorageException)
         {
             throw;
+        }
+        catch (BrokenCircuitException ex)
+        {
+            throw new InfrastructureUnavailableException("connector-state", ex);
         }
         catch (Exception ex)
         {
@@ -259,6 +269,10 @@ public sealed class ConnectorStateClient
         catch (StateStorageException)
         {
             throw;
+        }
+        catch (BrokenCircuitException ex)
+        {
+            throw new InfrastructureUnavailableException("connector-state", ex);
         }
         catch (Exception ex)
         {

--- a/template/netwrix-csharp/ConnectorFramework/Program.cs
+++ b/template/netwrix-csharp/ConnectorFramework/Program.cs
@@ -444,6 +444,7 @@ internal static class Program
             {
                 metrics.SetResourceBuilder(resourceBuilder)
                     .AddMeter(ConnectorMetrics.MeterName)
+                    .AddMeter("Netwrix.Overlord.Sdk.Orchestration") // CrawlRunOrchestratorMetrics.MeterName — use type constant once Sdk.Orchestration package is bumped
                     .AddHttpClientInstrumentation();
 
                 if (isHttpMode)


### PR DESCRIPTION
## Summary

- `ConnectorStateClient` now catches `BrokenCircuitException` (and `IsolatedCircuitException` via inheritance) at all three HTTP call sites (GET, POST, DELETE) and re-throws as `InfrastructureUnavailableException("connector-state", ex)`, so Module B can distinguish infrastructure outages from connector errors and requeue instead of finalising tasks as failed
- `BatchManager.PostBatchAsync` propagates `BrokenCircuitException` as `InfrastructureUnavailableException("data-ingestion", ex)` instead of swallowing it, preventing silent data loss when the data-ingestion circuit opens
- `Netwrix.Overlord.Sdk.Core` bumped to `2.0.0.25-preview` (first version containing `InfrastructureUnavailableException`)

## Test plan

- [ ] `ConnectorStateClientTests` — GET/POST/DELETE each throw `InfrastructureUnavailableException` when `BrokenCircuitException` is thrown by the HTTP handler; `IsolatedCircuitException` (subclass) also maps correctly
- [ ] `BatchManagerTests` — `FlushAsync` propagates `InfrastructureUnavailableException` on `BrokenCircuitException`; generic `HttpRequestException` is still swallowed (no regression)
- [ ] Full test suite: 187 pass, 0 fail

Closes AB#435934

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>