### PR TITLE
feat: add completed_with_errors state to Python connector templates

### DIFF
--- a/template/netwrix-internal-python/state_manager.py
+++ b/template/netwrix-internal-python/state_manager.py
@@ -60,14 +60,16 @@ class StateManager:
 
     # Valid state transitions
     VALID_TRANSITIONS: dict[str, list] = {
-        "running": ["stopping", "pausing", "completed", "failed"],
+        "running": ["stopping", "pausing", "completed", "completed_with_errors", "failed", "cancelled"],
         "stopping": ["stopped", "failed"],
         "stopped": [],
         "pausing": ["paused", "failed"],
-        "paused": ["resuming", "failed", "stopped"],
+        "paused": ["resuming", "failed", "stopped", "cancelled"],
         "resuming": ["running", "failed"],
         "completed": [],
+        "completed_with_errors": [],
         "failed": [],
+        "cancelled": [],
     }
 
     # Default supported states (all connectors can support stop)

--- a/template/netwrix-python/index.py
+++ b/template/netwrix-python/index.py
@@ -900,6 +900,13 @@ def call_handler(path: str):
                     elif response_status == "paused":
                         ctx.update_execution(status="paused")
                         ctx.log.info("Scan was paused", function_type=ctx.function_type, status="paused")
+                    elif response_status == "completed_with_errors":
+                        ctx.update_execution(status="completed_with_errors", completed_at=completed_at)
+                        ctx.log.info(
+                            f"Completed {ctx.function_type} operation with errors",
+                            function_type=ctx.function_type,
+                            status="completed_with_errors",
+                        )
                     else:
                         ctx.update_execution(status="completed", completed_at=completed_at)
                         ctx.log.info(
@@ -1005,6 +1012,13 @@ def run_as_job():
                     elif response_status == "paused":
                         ctx.update_execution(status="paused", completed_at=completed_at)
                         ctx.log.info("Operation was paused", function_type=ctx.function_type, status="paused")
+                    elif response_status == "completed_with_errors":
+                        ctx.update_execution(status="completed_with_errors", completed_at=completed_at)
+                        ctx.log.info(
+                            f"Completed {ctx.function_type} operation with errors",
+                            function_type=ctx.function_type,
+                            status="completed_with_errors",
+                        )
                     else:
                         ctx.update_execution(status="completed", completed_at=completed_at)
                         ctx.log.info(

--- a/template/netwrix-python/state_manager.py
+++ b/template/netwrix-python/state_manager.py
@@ -60,14 +60,16 @@ class StateManager:
 
     # Valid state transitions
     VALID_TRANSITIONS: dict[str, list] = {
-        "running": ["stopping", "pausing", "completed", "failed"],
+        "running": ["stopping", "pausing", "completed", "completed_with_errors", "failed", "cancelled"],
         "stopping": ["stopped", "failed"],
         "stopped": [],
         "pausing": ["paused", "failed"],
-        "paused": ["resuming", "failed", "stopped"],
+        "paused": ["resuming", "failed", "stopped", "cancelled"],
         "resuming": ["running", "failed"],
         "completed": [],
+        "completed_with_errors": [],
         "failed": [],
+        "cancelled": [],
     }
 
     # Default supported states (all connectors can support stop)


### PR DESCRIPTION
Add completed_with_errors as a valid terminal state in StateManager                                                                                                                        
  and thread it through the execution status update logic in index.py.                                                                                                                       
                                                                                                                                                                                             
  - Add completed_with_errors and cancelled to VALID_TRANSITIONS in                                                                                                                          
    both netwrix-python and netwrix-internal-python state_manager.py,                                                                                                                        
    aligned with the core-api scan_executions_controller state machine                                                                                                                       
  - Handle completed_with_errors in call_handler and run_as_job so                                                                                                                           
    a handler returning status=completed_with_errors is passed through                                                                                                                       
    to update_execution rather than overwritten with completed