### PR TITLE
feat(connector-state): migrate to path-based routing and add data streaming

### DIFF
--- a/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorFramework.Tests.csproj
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorFramework.Tests.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <NoWarn>CA2007;CA2016;CA2201</NoWarn>
+    <NoWarn>CA2007;CA2016;CA2201;CA1852</NoWarn>
     <RootNamespace>Netwrix.ConnectorFramework.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateClientRouteTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateClientRouteTests.cs
@@ -1,0 +1,265 @@
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Moq.Protected;
+using Netwrix.Overlord.Sdk.Core.Storage.Exceptions;
+using Xunit;
+
+namespace Netwrix.ConnectorFramework.Tests;
+
+public class ConnectorStateClientRouteTests
+{
+    private record CapturedRequest(HttpMethod Method, string Path, string? Query, string Body);
+
+    private static (ConnectorStateClient client, List<CapturedRequest> captured) CreateClient(
+        HttpStatusCode statusCode = HttpStatusCode.OK,
+        string responseBody = "{}")
+    {
+        var captured = new List<CapturedRequest>();
+
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(async (HttpRequestMessage req, CancellationToken ct) =>
+            {
+                var body = req.Content is not null
+                    ? await req.Content.ReadAsStringAsync(ct)
+                    : string.Empty;
+                captured.Add(new CapturedRequest(
+                    req.Method,
+                    req.RequestUri!.AbsolutePath,
+                    req.RequestUri.Query,
+                    body));
+                return new HttpResponseMessage(statusCode)
+                {
+                    Content = new StringContent(responseBody, Encoding.UTF8, "application/json"),
+                };
+            });
+
+        var client = new ConnectorStateClient(
+            new HttpClient(handlerMock.Object) { BaseAddress = new Uri("http://connector-state/") },
+            NullLogger<ConnectorStateClient>.Instance);
+
+        return (client, captured);
+    }
+
+    // ── GetStateAsync ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetStateAsync_Sends_GET_To_ScanId_Path()
+    {
+        var (client, captured) = CreateClient(responseBody: "{\"k\":\"v\"}");
+        await client.GetStateAsync("scan-1", null, CancellationToken.None);
+        Assert.Single(captured);
+        Assert.Equal(HttpMethod.Get, captured[0].Method);
+        Assert.Equal("/scan-1", captured[0].Path);
+    }
+
+    [Fact]
+    public async Task GetStateAsync_Returns_EmptyDict_On404()
+    {
+        var (client, _) = CreateClient(HttpStatusCode.NotFound);
+        var result = await client.GetStateAsync("scan-1", null, CancellationToken.None);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetStateAsync_Deserializes_Response_Dict()
+    {
+        var (client, _) = CreateClient(responseBody: "{\"key1\":\"val1\",\"key2\":\"val2\"}");
+        var result = await client.GetStateAsync("scan-1", null, CancellationToken.None);
+        Assert.Equal("val1", result["key1"]);
+        Assert.Equal("val2", result["key2"]);
+    }
+
+    // ── ListKeysAsync ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListKeysAsync_Sends_GET_To_Keys_Path()
+    {
+        var (client, captured) = CreateClient(responseBody: "[]");
+        await client.ListKeysAsync("scan-1", null, CancellationToken.None);
+        Assert.Single(captured);
+        Assert.Equal(HttpMethod.Get, captured[0].Method);
+        Assert.Equal("/scan-1/keys", captured[0].Path);
+    }
+
+    [Fact]
+    public async Task ListKeysAsync_Returns_EmptyArray_On404()
+    {
+        var (client, _) = CreateClient(HttpStatusCode.NotFound);
+        var result = await client.ListKeysAsync("scan-1", null, CancellationToken.None);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task ListKeysAsync_Deserializes_Key_Array()
+    {
+        var (client, _) = CreateClient(responseBody: "[\"key1\",\"key2\",\"key3\"]");
+        var result = await client.ListKeysAsync("scan-1", null, CancellationToken.None);
+        Assert.Equal(["key1", "key2", "key3"], result);
+    }
+
+    // ── GetStateValueAsync ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetStateValueAsync_Sends_GET_To_Key_Path()
+    {
+        var (client, captured) = CreateClient(responseBody: "{\"mykey\":\"myvalue\"}");
+        await client.GetStateValueAsync("scan-1", null, "mykey", CancellationToken.None);
+        Assert.Single(captured);
+        Assert.Equal(HttpMethod.Get, captured[0].Method);
+        Assert.Equal("/scan-1/keys/mykey", captured[0].Path);
+    }
+
+    [Fact]
+    public async Task GetStateValueAsync_Returns_Null_On404()
+    {
+        var (client, _) = CreateClient(HttpStatusCode.NotFound);
+        var result = await client.GetStateValueAsync("scan-1", null, "mykey", CancellationToken.None);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetStateValueAsync_Returns_Value_From_Response()
+    {
+        var (client, _) = CreateClient(responseBody: "{\"mykey\":\"myvalue\"}");
+        var result = await client.GetStateValueAsync("scan-1", null, "mykey", CancellationToken.None);
+        Assert.Equal("myvalue", result);
+    }
+
+    [Fact]
+    public async Task GetStateValueAsync_Escapes_Key_In_Path()
+    {
+        var (client, captured) = CreateClient(responseBody: "{\"my/key\":\"v\"}");
+        await client.GetStateValueAsync("scan-1", null, "my/key", CancellationToken.None);
+        Assert.Equal("/scan-1/keys/my%2Fkey", captured[0].Path);
+    }
+
+    // ── PostStateAsync ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PostStateAsync_Sends_POST_To_ScanId_Path()
+    {
+        var (client, captured) = CreateClient();
+        await client.PostStateAsync("scan-1", null, new Dictionary<string, string> { ["k"] = "v" }, CancellationToken.None);
+        Assert.Single(captured);
+        Assert.Equal(HttpMethod.Post, captured[0].Method);
+        Assert.Equal("/scan-1", captured[0].Path);
+    }
+
+    [Fact]
+    public async Task PostStateAsync_Sends_Data_As_Json_Body()
+    {
+        var (client, captured) = CreateClient();
+        await client.PostStateAsync("scan-1", null, new Dictionary<string, string> { ["key1"] = "val1" }, CancellationToken.None);
+        Assert.Contains("\"key1\"", captured[0].Body);
+        Assert.Contains("\"val1\"", captured[0].Body);
+    }
+
+    [Fact]
+    public async Task PostStateAsync_Does_Not_Include_ScanId_In_Body()
+    {
+        var (client, captured) = CreateClient();
+        await client.PostStateAsync("scan-1", null, new Dictionary<string, string> { ["k"] = "v" }, CancellationToken.None);
+        Assert.DoesNotContain("scanId", captured[0].Body);
+    }
+
+    // ── DeleteManyAsync ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteManyAsync_Sends_DELETE_To_Keys_Path()
+    {
+        var (client, captured) = CreateClient();
+        await client.DeleteManyAsync("scan-1", null, ["key1", "key2"], CancellationToken.None);
+        Assert.Single(captured);
+        Assert.Equal(HttpMethod.Delete, captured[0].Method);
+        Assert.Equal("/scan-1/keys", captured[0].Path);
+    }
+
+    [Fact]
+    public async Task DeleteManyAsync_Sends_Names_As_Json_Array_Body()
+    {
+        var (client, captured) = CreateClient();
+        await client.DeleteManyAsync("scan-1", null, ["key1", "key2"], CancellationToken.None);
+        Assert.Contains("\"key1\"", captured[0].Body);
+        Assert.Contains("\"key2\"", captured[0].Body);
+    }
+
+    [Fact]
+    public async Task DeleteManyAsync_Sends_No_Request_When_Names_Empty()
+    {
+        var (client, captured) = CreateClient();
+        await client.DeleteManyAsync("scan-1", null, [], CancellationToken.None);
+        Assert.Empty(captured);
+    }
+
+    [Fact]
+    public async Task DeleteManyAsync_Treats_404_As_Success()
+    {
+        var (client, _) = CreateClient(HttpStatusCode.NotFound);
+        await client.DeleteManyAsync("scan-1", null, ["key1"], CancellationToken.None);
+        // no exception thrown
+    }
+
+    // ── DeleteByPrefixAsync ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteByPrefixAsync_EmptyPrefix_Sends_DELETE_To_ScanId_Path()
+    {
+        var (client, captured) = CreateClient();
+        await client.DeleteByPrefixAsync("scan-1", null, "", CancellationToken.None);
+        Assert.Single(captured);
+        Assert.Equal(HttpMethod.Delete, captured[0].Method);
+        Assert.Equal("/scan-1", captured[0].Path);
+        Assert.Equal(string.Empty, captured[0].Query);
+    }
+
+    [Fact]
+    public async Task DeleteByPrefixAsync_WithPrefix_Sends_DELETE_To_Keys_Path_With_Query()
+    {
+        var (client, captured) = CreateClient();
+        await client.DeleteByPrefixAsync("scan-1", null, "myprefix", CancellationToken.None);
+        Assert.Single(captured);
+        Assert.Equal(HttpMethod.Delete, captured[0].Method);
+        Assert.Equal("/scan-1/keys", captured[0].Path);
+        Assert.Contains("prefix=myprefix", captured[0].Query);
+    }
+
+    [Fact]
+    public async Task DeleteByPrefixAsync_Treats_404_As_Success()
+    {
+        var (client, _) = CreateClient(HttpStatusCode.NotFound);
+        await client.DeleteByPrefixAsync("scan-1", null, "prefix", CancellationToken.None);
+        // no exception thrown
+    }
+
+    // ── Error handling ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetStateAsync_Throws_StateStorageException_On_500()
+    {
+        var (client, _) = CreateClient(HttpStatusCode.InternalServerError);
+        await Assert.ThrowsAsync<StateStorageException>(
+            () => client.GetStateAsync("scan-1", null, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task PostStateAsync_Throws_StateStorageException_On_500()
+    {
+        var (client, _) = CreateClient(HttpStatusCode.InternalServerError);
+        await Assert.ThrowsAsync<StateStorageException>(
+            () => client.PostStateAsync("scan-1", null, new Dictionary<string, string> { ["k"] = "v" }, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task DeleteManyAsync_Throws_StateStorageException_On_500()
+    {
+        var (client, _) = CreateClient(HttpStatusCode.InternalServerError);
+        await Assert.ThrowsAsync<StateStorageException>(
+            () => client.DeleteManyAsync("scan-1", null, ["key1"], CancellationToken.None));
+    }
+}

--- a/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateClientTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateClientTests.cs
@@ -43,12 +43,12 @@ public class ConnectorStateClientTests
     }
 
     [Fact]
-    public async Task PostStateAsync_BrokenCircuit_ThrowsInfrastructureUnavailable()
+    public async Task PutStateAsync_BrokenCircuit_ThrowsInfrastructureUnavailable()
     {
         var client = CreateClientThrowing(new BrokenCircuitException("circuit open"));
 
         var ex = await Assert.ThrowsAsync<InfrastructureUnavailableException>(
-            () => client.PostStateAsync("scan-1", null, new Dictionary<string, string>(), CancellationToken.None));
+            () => client.PutStateAsync("scan-1", null, new Dictionary<string, string>(), CancellationToken.None));
 
         Assert.Contains("connector-state", ex.Message);
     }

--- a/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateClientTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateClientTests.cs
@@ -43,12 +43,12 @@ public class ConnectorStateClientTests
     }
 
     [Fact]
-    public async Task PutStateAsync_BrokenCircuit_ThrowsInfrastructureUnavailable()
+    public async Task PostStateAsync_BrokenCircuit_ThrowsInfrastructureUnavailable()
     {
         var client = CreateClientThrowing(new BrokenCircuitException("circuit open"));
 
         var ex = await Assert.ThrowsAsync<InfrastructureUnavailableException>(
-            () => client.PutStateAsync("scan-1", null, new Dictionary<string, string>(), CancellationToken.None));
+            () => client.PostStateAsync("scan-1", null, new Dictionary<string, string>(), CancellationToken.None));
 
         Assert.Contains("connector-state", ex.Message);
     }

--- a/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateStorageTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/ConnectorStateStorageTests.cs
@@ -45,18 +45,20 @@ public class ConnectorStateStorageTests
     private static ConnectorStateStorage CreateStorage(ConnectorStateClient client, string? scanId = "scan-test")
         => new(MakeRequest(scanId), client, NullLogger<ConnectorStateStorage>.Instance);
 
-    private static string StateResponse(Dictionary<string, string> data)
-        => JsonSerializer.Serialize(new { success = true, data });
+    /// <summary>Flat JSON dict — the format returned by GET /{scanId} and GET /{scanId}/keys/{key}.</summary>
+    private static string FlatState(Dictionary<string, string> data)
+        => JsonSerializer.Serialize(data);
 
-    private static string EmptyStateResponse()
-        => JsonSerializer.Serialize(new { success = true, data = new Dictionary<string, string>() });
+    /// <summary>JSON array — the format returned by GET /{scanId}/keys.</summary>
+    private static string KeyList(params string[] keys)
+        => JsonSerializer.Serialize(keys);
 
     // ── TryGetAsync ──────────────────────────────────────────────────────────
 
     [Fact]
     public async Task TryGetAsync_ReturnsNotFound_WhenKeyAbsent()
     {
-        var storage = CreateStorage(CreateClient(EmptyStateResponse()));
+        var storage = CreateStorage(CreateClient("{}", HttpStatusCode.NotFound));
 
         var result = await storage.TryGetAsync<string>("missing");
 
@@ -66,11 +68,8 @@ public class ConnectorStateStorageTests
     [Fact]
     public async Task TryGetAsync_ReturnsValue_WhenFound()
     {
-        var stateData = new Dictionary<string, string>
-        {
-            ["myKey"] = "\"hello\"",
-        };
-        var storage = CreateStorage(CreateClient(StateResponse(stateData)));
+        var stateData = new Dictionary<string, string> { ["myKey"] = "\"hello\"" };
+        var storage = CreateStorage(CreateClient(FlatState(stateData)));
 
         var result = await storage.TryGetAsync<string>("myKey");
 
@@ -132,6 +131,7 @@ public class ConnectorStateStorageTests
         var json = Encoding.UTF8.GetString(capturedBody!);
         Assert.Contains("\"cursor\"", json);
         Assert.Contains("page-5", json);
+        Assert.DoesNotContain("scanId", json);
         Assert.DoesNotContain("__etag__", json);
     }
 
@@ -179,6 +179,7 @@ public class ConnectorStateStorageTests
         var json = Encoding.UTF8.GetString(capturedBody!);
         Assert.Contains("\"bookmark\"", json);
         Assert.Contains("value-new", json);
+        Assert.DoesNotContain("scanId", json);
         Assert.Equal(string.Empty, result);
     }
 
@@ -188,17 +189,19 @@ public class ConnectorStateStorageTests
     public async Task DeleteAsync_ReturnsTrueAndIssuesDelete()
     {
         HttpMethod? deleteMethod = null;
-        string? deleteUrl = null;
+        string? deletePath = null;
+        string? deleteBody = null;
         var handlerMock = new Mock<HttpMessageHandler>();
         handlerMock.Protected()
             .Setup<Task<HttpResponseMessage>>("SendAsync",
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>())
-            .Returns<HttpRequestMessage, CancellationToken>((req, _) =>
+            .Returns<HttpRequestMessage, CancellationToken>(async (req, _) =>
             {
                 deleteMethod = req.Method;
-                deleteUrl = req.RequestUri!.ToString();
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+                deletePath = req.RequestUri!.AbsolutePath;
+                deleteBody = req.Content is not null ? await req.Content.ReadAsStringAsync() : null;
+                return new HttpResponseMessage(HttpStatusCode.OK);
             });
         var storage = CreateStorage(CreateClient(handlerMock.Object));
 
@@ -206,8 +209,9 @@ public class ConnectorStateStorageTests
 
         Assert.True(deleted);
         Assert.Equal(HttpMethod.Delete, deleteMethod);
-        Assert.NotNull(deleteUrl);
-        Assert.Contains("name=target", deleteUrl);
+        Assert.Equal("/scan-test/keys", deletePath);
+        Assert.NotNull(deleteBody);
+        Assert.Contains("target", deleteBody);
     }
 
     [Fact]
@@ -237,159 +241,54 @@ public class ConnectorStateStorageTests
     // ── DeleteAllAsync ────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task DeleteAllAsync_IssuesDeleteForPrefixMatchingKeys()
+    public async Task DeleteAllAsync_IssuesSingleDeleteWithPrefixQuery()
     {
-        var stateData = new Dictionary<string, string>
-        {
-            ["source/abc/bookmark"] = "\"v1\"",
-            ["source/abc/cursor"] = "\"v2\"",
-            ["other/key"] = "\"v3\"",
-        };
-        var deleteRequests = new List<string>();
+        HttpMethod? deleteMethod = null;
+        string? deletePath = null;
+        string? deleteQuery = null;
         var handlerMock = new Mock<HttpMessageHandler>();
-        var callIndex = 0;
         handlerMock.Protected()
             .Setup<Task<HttpResponseMessage>>("SendAsync",
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>())
             .Returns<HttpRequestMessage, CancellationToken>((req, _) =>
             {
-                if (callIndex++ == 0)
-                {
-                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                    {
-                        Content = new StringContent(StateResponse(stateData), Encoding.UTF8, "application/json"),
-                    });
-                }
-                deleteRequests.Add(req.RequestUri!.ToString());
+                deleteMethod = req.Method;
+                deletePath = req.RequestUri!.AbsolutePath;
+                deleteQuery = req.RequestUri.Query;
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
             });
         var storage = CreateStorage(CreateClient(handlerMock.Object));
 
         await storage.DeleteAllAsync("source/abc");
 
-        Assert.Single(deleteRequests);
-        var deleteUrl = deleteRequests[0];
-        Assert.True(deleteUrl.Contains("bookmark") && deleteUrl.Contains("cursor"),
-            $"Expected both bookmark and cursor in DELETE url: {deleteUrl}");
-        Assert.DoesNotContain("other%2Fkey", deleteUrl);
-        Assert.DoesNotContain("other/key", deleteUrl);
+        Assert.Equal(HttpMethod.Delete, deleteMethod);
+        Assert.Equal("/scan-test/keys", deletePath);
+        Assert.Contains("prefix=source%2Fabc", deleteQuery);
     }
 
     [Fact]
-    public async Task DeleteAllAsync_BatchesDeleteRequests_WhenUrlLengthWouldExceedLimit()
+    public async Task DeleteAllAsync_EmptyPrefix_DeletesAllState()
     {
-        // ConnectorStateClient.DeleteManyAsync batches by URL length (MaxDeleteQueryLength = 4,000)
-        // rather than by a fixed key count. This prevents UriFormatException for long key names
-        // and respects proxy URL size limits.
-        //
-        // Key format: "source/abc/item-NNNNNN" (22 chars, URL-encoded to 26 chars due to '/' → '%2F').
-        // Per-key query segment: "&name=" (6) + 26 = 32 chars.
-        // Base: "?scanId=scan-test" = 18 chars. Available per batch: 4,000 - 18 = 3,982.
-        // Keys per batch: floor(3,982 / 32) = 124. For 300 keys: ceil(300 / 124) = 3 batches.
-        const int keyCount = 300;
-        const string prefix = "source/abc";
-
-        var stateData = Enumerable.Range(0, keyCount)
-            .ToDictionary(i => $"{prefix}/item-{i:D6}", _ => "\"v\"");
-
-        var deleteRequests = new List<string>();
+        HttpMethod? deleteMethod = null;
+        string? deletePath = null;
         var handlerMock = new Mock<HttpMessageHandler>();
-        var callIndex = 0;
         handlerMock.Protected()
             .Setup<Task<HttpResponseMessage>>("SendAsync",
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>())
             .Returns<HttpRequestMessage, CancellationToken>((req, _) =>
             {
-                if (callIndex++ == 0)
-                {
-                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                    {
-                        Content = new StringContent(StateResponse(stateData), Encoding.UTF8, "application/json"),
-                    });
-                }
-                deleteRequests.Add(req.RequestUri!.ToString());
+                deleteMethod = req.Method;
+                deletePath = req.RequestUri!.AbsolutePath;
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
             });
         var storage = CreateStorage(CreateClient(handlerMock.Object));
 
-        await storage.DeleteAllAsync(prefix);
+        await storage.DeleteAllAsync("");
 
-        Assert.Equal(3, deleteRequests.Count);
-
-        // No single batch URL's query portion should exceed MaxDeleteQueryLength
-        const string baseUrl = "http://connector-state/";
-        foreach (var url in deleteRequests)
-        {
-            var queryLength = url.Length - baseUrl.Length;
-            Assert.True(
-                queryLength <= ConnectorStateClient.MaxDeleteQueryLength,
-                $"Batch query exceeded {ConnectorStateClient.MaxDeleteQueryLength} chars ({queryLength}): {url[..Math.Min(200, url.Length)]}");
-        }
-
-        // Every key must appear in exactly one batch
-        var allDeletedKeys = deleteRequests
-            .SelectMany(url => url.Split('&')
-                .Where(p => p.StartsWith("name=", StringComparison.Ordinal))
-                .Select(p => Uri.UnescapeDataString(p["name=".Length..])))
-            .ToHashSet();
-        Assert.Equal(keyCount, allDeletedKeys.Count);
-        Assert.All(stateData.Keys, k => Assert.Contains(k, allDeletedKeys));
-    }
-
-    [Fact]
-    public async Task DeleteAllAsync_CompletesSafely_WhenTotalUrlWouldExceedNetUriLimit()
-    {
-        // Without URL-length-based batching, a single DELETE with these 100 keys would produce
-        // a query string of ~72,018 chars, exceeding .NET's ~65,519-char URI limit and throwing
-        // System.UriFormatException: Invalid URI: The Uri string is too long.
-        //
-        // Key format: "source/abc/" (11 chars) + 694 'a's + 5-digit index = 710 chars.
-        // URL-encoded: "source%2Fabc%2F" (15) + 694 + 5 = 714 chars.
-        // Per-key query segment: "&name=" (6) + 714 = 720 chars.
-        // 100 keys unbatched: 18 + 100 × 720 = 72,018 chars → UriFormatException.
-        // With MaxDeleteQueryLength = 4,000: floor((4,000-18)/720) = 5 keys/batch → 20 batches.
-        const int keyCount = 100;
-        const string prefix = "source/abc";
-
-        var stateData = Enumerable.Range(0, keyCount)
-            .ToDictionary(i => $"{prefix}/{new string('a', 694)}{i:D5}", _ => "\"v\"");
-
-        var deleteRequests = new List<string>();
-        var handlerMock = new Mock<HttpMessageHandler>();
-        var callIndex = 0;
-        handlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .Returns<HttpRequestMessage, CancellationToken>((req, _) =>
-            {
-                if (callIndex++ == 0)
-                {
-                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                    {
-                        Content = new StringContent(StateResponse(stateData), Encoding.UTF8, "application/json"),
-                    });
-                }
-                deleteRequests.Add(req.RequestUri!.ToString());
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
-            });
-        var storage = CreateStorage(CreateClient(handlerMock.Object));
-
-        await storage.DeleteAllAsync(prefix);
-
-        // Completed without UriFormatException — multiple batches were required
-        Assert.True(deleteRequests.Count > 1, "Expected more than one DELETE batch for long-key workload");
-
-        // Every key must appear in exactly one batch
-        var allDeletedKeys = deleteRequests
-            .SelectMany(url => url.Split('&')
-                .Where(p => p.StartsWith("name=", StringComparison.Ordinal))
-                .Select(p => Uri.UnescapeDataString(p["name=".Length..])))
-            .ToHashSet();
-        Assert.Equal(keyCount, allDeletedKeys.Count);
-        Assert.All(stateData.Keys, k => Assert.Contains(k, allDeletedKeys));
+        Assert.Equal(HttpMethod.Delete, deleteMethod);
+        Assert.Equal("/scan-test", deletePath);
     }
 
     // ── ListAllKeysAsync ──────────────────────────────────────────────────────
@@ -397,13 +296,7 @@ public class ConnectorStateStorageTests
     [Fact]
     public async Task ListAllKeysAsync_ReturnsKeys_MatchingPrefix()
     {
-        var stateData = new Dictionary<string, string>
-        {
-            ["a/x"] = "\"1\"",
-            ["a/y"] = "\"2\"",
-            ["b/z"] = "\"3\"",
-        };
-        var storage = CreateStorage(CreateClient(StateResponse(stateData)));
+        var storage = CreateStorage(CreateClient(KeyList("a/x", "a/y", "b/z")));
 
         var keys = new List<string>();
         await foreach (var k in storage.ListAllKeysAsync("a"))
@@ -444,14 +337,12 @@ public class ConnectorStateStorageTests
     [Fact]
     public async Task ListKeysAsync_ReturnsKeysAtCorrectDepth()
     {
-        var stateData = new Dictionary<string, string>
-        {
-            ["src/tenant/site/bookmark"] = "\"v\"",
-            ["src/tenant/site/cursor"] = "\"v\"",
-            ["src/tenant/other/bookmark"] = "\"v\"",
-            ["src/tenant/bookmark"] = "\"v\"", // depth=1 from src/tenant
-        };
-        var storage = CreateStorage(CreateClient(StateResponse(stateData)));
+        var allKeys = KeyList(
+            "src/tenant/bookmark",
+            "src/tenant/other/bookmark",
+            "src/tenant/site/bookmark",
+            "src/tenant/site/cursor");
+        var storage = CreateStorage(CreateClient(allKeys));
 
         var depth1 = new List<string>();
         await foreach (var k in storage.ListKeysAsync("src/tenant", depth: 1))
@@ -483,7 +374,7 @@ public class ConnectorStateStorageTests
             .Returns<HttpRequestMessage, CancellationToken>((_, _) =>
                 Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent(StateResponse(stateData), Encoding.UTF8, "application/json"),
+                    Content = new StringContent(FlatState(stateData), Encoding.UTF8, "application/json"),
                 }));
         var storage = CreateStorage(CreateClient(handlerMock.Object));
 
@@ -496,8 +387,10 @@ public class ConnectorStateStorageTests
     }
 
     [Fact]
-    public async Task TryGetAsync_AndDeleteAllAsync_IssueIndependentGets()
+    public async Task TryGetAsync_AndDeleteAllAsync_IssueIndependentRequests()
     {
+        // TryGetAsync issues one GET; DeleteAllAsync now issues one DELETE directly
+        // (no GET to fetch state first), so total GET count should be 1.
         var stateData = new Dictionary<string, string>
         {
             ["prefix/a"] = "\"v\"",
@@ -518,7 +411,7 @@ public class ConnectorStateStorageTests
 
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent(StateResponse(stateData), Encoding.UTF8, "application/json"),
+                    Content = new StringContent(FlatState(stateData), Encoding.UTF8, "application/json"),
                 });
             });
         var storage = CreateStorage(CreateClient(handlerMock.Object));
@@ -526,7 +419,7 @@ public class ConnectorStateStorageTests
         await storage.TryGetAsync<string>("prefix/a");
         await storage.DeleteAllAsync("prefix");
 
-        Assert.Equal(2, getCount);
+        Assert.Equal(1, getCount);
     }
 
     // ── GetStateValueAsync ────────────────────────────────────────────────────
@@ -534,8 +427,7 @@ public class ConnectorStateStorageTests
     [Fact]
     public async Task GetStateValueAsync_ReturnsNull_WhenKeyAbsent()
     {
-        var stateData = new Dictionary<string, string> { ["other"] = "\"v\"" };
-        var client = CreateClient(StateResponse(stateData));
+        var client = CreateClient("{}", HttpStatusCode.NotFound);
 
         var result = await client.GetStateValueAsync("scan-id", null, "missing", CancellationToken.None);
 

--- a/template/netwrix-csharp/ConnectorFramework.Tests/ResilienceRegistrationTests.cs
+++ b/template/netwrix-csharp/ConnectorFramework.Tests/ResilienceRegistrationTests.cs
@@ -62,7 +62,7 @@ public class ResilienceRegistrationTests
             sequence = sequence.ReturnsAsync(() => new HttpResponseMessage(captured)
             {
                 Content = new StringContent(
-                    """{"success":true,"data":{}}""",
+                    "{}",
                     System.Text.Encoding.UTF8,
                     "application/json"),
             });

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorStateClient.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorStateClient.cs
@@ -189,6 +189,53 @@ public sealed class ConnectorStateClient
     }
 
     /// <summary>
+    /// Deletes all keys whose names match <paramref name="keyPrefix"/> for <paramref name="scanId"/>.
+    /// An empty prefix deletes all state for the scan.
+    /// </summary>
+    /// <param name="scanId">The scan whose state to delete.</param>
+    /// <param name="scanExecutionId">Optional execution ID forwarded as a request header for tracing.</param>
+    /// <param name="keyPrefix">Prefix to match. Empty string deletes all state for the scan.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public async Task DeleteByPrefixAsync(
+        string scanId, string? scanExecutionId, string keyPrefix, CancellationToken ct)
+    {
+        var url = string.IsNullOrEmpty(keyPrefix)
+            ? $"/{Uri.EscapeDataString(scanId)}"
+            : $"/{Uri.EscapeDataString(scanId)}/keys?prefix={Uri.EscapeDataString(keyPrefix)}";
+
+        using var request = new HttpRequestMessage(HttpMethod.Delete, url);
+        AddPerRequestHeaders(request, scanId, scanExecutionId);
+
+        try
+        {
+            using var response = await _client.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode &&
+                response.StatusCode != System.Net.HttpStatusCode.NotFound)
+            {
+                throw new StateStorageException(
+                    $"connector-state DELETE returned {(int)response.StatusCode}");
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (StateStorageException)
+        {
+            throw;
+        }
+        catch (BrokenCircuitException ex)
+        {
+            throw new InfrastructureUnavailableException("connector-state", ex);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "connector-state DELETE failed for scan {ScanId}", scanId);
+            throw new StateStorageException($"connector-state DELETE failed for scan {scanId}", ex);
+        }
+    }
+
+    /// <summary>
     /// Writes (upserts) the key-value pairs in <paramref name="data"/> into the connector-state
     /// service for <paramref name="scanId"/>.
     /// </summary>

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorStateClient.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorStateClient.cs
@@ -243,10 +243,10 @@ public sealed class ConnectorStateClient
     /// <param name="scanExecutionId">Optional execution ID forwarded as a request header for tracing.</param>
     /// <param name="data">Key-value pairs to upsert.</param>
     /// <param name="ct">Cancellation token.</param>
-    public async Task PutStateAsync(
+    public async Task PostStateAsync(
         string scanId, string? scanExecutionId, Dictionary<string, string> data, CancellationToken ct)
     {
-        using var request = new HttpRequestMessage(HttpMethod.Put, $"/{Uri.EscapeDataString(scanId)}")
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"/{Uri.EscapeDataString(scanId)}")
         {
             Content = new StringContent(
                 JsonSerializer.Serialize(data), Encoding.UTF8, "application/json"),
@@ -259,7 +259,7 @@ public sealed class ConnectorStateClient
             if (!response.IsSuccessStatusCode)
             {
                 throw new StateStorageException(
-                    $"connector-state PUT returned {(int)response.StatusCode}");
+                    $"connector-state POST returned {(int)response.StatusCode}");
             }
         }
         catch (OperationCanceledException)
@@ -276,8 +276,8 @@ public sealed class ConnectorStateClient
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "connector-state PUT failed for scan {ScanId}", scanId);
-            throw new StateStorageException($"connector-state PUT failed for scan {scanId}", ex);
+            _logger.LogError(ex, "connector-state POST failed for scan {ScanId}", scanId);
+            throw new StateStorageException($"connector-state POST failed for scan {scanId}", ex);
         }
     }
 

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorStateClient.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorStateClient.cs
@@ -18,11 +18,6 @@ public sealed class ConnectorStateClient
     /// <summary>Named client key used in both DI registration and singleton factory creation.</summary>
     public const string HttpClientName = "connector-state";
 
-    // Maximum query-string length for a single DELETE request. Each key becomes a &name=
-    // query parameter; splitting into batches prevents UriFormatException (.NET URI limit
-    // is ~65,519 chars) and respects typical proxy/nginx URL size limits (~8 KB).
-    internal const int MaxDeleteQueryLength = 4_000;
-
     private readonly HttpClient _client;
     private readonly ILogger<ConnectorStateClient> _logger;
 
@@ -44,14 +39,57 @@ public sealed class ConnectorStateClient
     public async Task<Dictionary<string, string>> GetStateAsync(
         string scanId, string? scanExecutionId, CancellationToken ct)
     {
-        using var doc = await OpenStateDocumentAsync(scanId, scanExecutionId, ct);
-        var root = doc.RootElement;
-        if (root.TryGetProperty("data", out var dataProp))
-        {
-            return dataProp.Deserialize<Dictionary<string, string>>() ?? new Dictionary<string, string>();
-        }
+        return await FetchStateAsync(scanId, scanExecutionId, ct);
+    }
 
-        return new Dictionary<string, string>();
+    /// <summary>
+    /// Returns all key names stored for <paramref name="scanId"/>, or an empty array if none exist.
+    /// </summary>
+    /// <param name="scanId">The scan whose state keys to list.</param>
+    /// <param name="scanExecutionId">Optional execution ID forwarded as a request header for tracing.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public async Task<string[]> ListKeysAsync(
+        string scanId, string? scanExecutionId, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/{Uri.EscapeDataString(scanId)}/keys");
+        AddPerRequestHeaders(request, scanId, scanExecutionId);
+
+        try
+        {
+            using var response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+                return [];
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new StateStorageException(
+                    $"connector-state GET keys returned {(int)response.StatusCode}");
+            }
+
+            await using var stream = await response.Content.ReadAsStreamAsync(ct);
+            return await JsonSerializer.DeserializeAsync<string[]>(stream, cancellationToken: ct)
+                ?? [];
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (StateStorageException)
+        {
+            throw;
+        }
+        catch (BrokenCircuitException ex)
+        {
+            throw new InfrastructureUnavailableException("connector-state", ex);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "connector-state GET keys failed for scan {ScanId}", scanId);
+            throw new StateStorageException($"connector-state GET keys failed for scan {scanId}", ex);
+        }
     }
 
     /// <summary>
@@ -65,28 +103,62 @@ public sealed class ConnectorStateClient
     public async Task<string?> GetStateValueAsync(
         string scanId, string? scanExecutionId, string key, CancellationToken ct)
     {
-        using var doc = await OpenStateDocumentAsync(scanId, scanExecutionId, ct);
-        var root = doc.RootElement;
-        if (root.TryGetProperty("data", out var dataProp) &&
-            dataProp.TryGetProperty(key, out var valueProp))
-        {
-            return valueProp.GetString();
-        }
-
-        return null;
-    }
-
-    private async Task<JsonDocument> OpenStateDocumentAsync(
-        string scanId, string? scanExecutionId, CancellationToken ct)
-    {
         using var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"?scanId={Uri.EscapeDataString(scanId)}");
+            $"/{Uri.EscapeDataString(scanId)}/keys/{Uri.EscapeDataString(key)}");
         AddPerRequestHeaders(request, scanId, scanExecutionId);
 
         try
         {
             using var response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+                return null;
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new StateStorageException(
+                    $"connector-state GET key returned {(int)response.StatusCode}");
+            }
+
+            await using var stream = await response.Content.ReadAsStreamAsync(ct);
+            var dict = await JsonSerializer.DeserializeAsync<Dictionary<string, string>>(stream, cancellationToken: ct);
+            return dict?.TryGetValue(key, out var value) == true ? value : null;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (StateStorageException)
+        {
+            throw;
+        }
+        catch (BrokenCircuitException ex)
+        {
+            throw new InfrastructureUnavailableException("connector-state", ex);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "connector-state GET key failed for scan {ScanId}, key {Key}", scanId, key);
+            throw new StateStorageException($"connector-state GET key failed for scan {scanId}", ex);
+        }
+    }
+
+    private async Task<Dictionary<string, string>> FetchStateAsync(
+        string scanId, string? scanExecutionId, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/{Uri.EscapeDataString(scanId)}");
+        AddPerRequestHeaders(request, scanId, scanExecutionId);
+
+        try
+        {
+            using var response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+                return new Dictionary<string, string>();
+
             if (!response.IsSuccessStatusCode)
             {
                 throw new StateStorageException(
@@ -94,18 +166,8 @@ public sealed class ConnectorStateClient
             }
 
             await using var stream = await response.Content.ReadAsStreamAsync(ct);
-            var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct);
-            var root = doc.RootElement;
-
-            if (!root.TryGetProperty("success", out var successProp) || !successProp.GetBoolean())
-            {
-                doc.Dispose();
-                var error = root.TryGetProperty("error", out var errProp)
-                    ? errProp.GetString() : "Unknown error";
-                throw new StateStorageException($"connector-state GET failed: {error}");
-            }
-
-            return doc;
+            return await JsonSerializer.DeserializeAsync<Dictionary<string, string>>(stream, cancellationToken: ct)
+                ?? new Dictionary<string, string>();
         }
         catch (OperationCanceledException)
         {
@@ -134,14 +196,13 @@ public sealed class ConnectorStateClient
     /// <param name="scanExecutionId">Optional execution ID forwarded as a request header for tracing.</param>
     /// <param name="data">Key-value pairs to upsert.</param>
     /// <param name="ct">Cancellation token.</param>
-    public async Task PostStateAsync(
+    public async Task PutStateAsync(
         string scanId, string? scanExecutionId, Dictionary<string, string> data, CancellationToken ct)
     {
-        var payload = new { scanId, data };
-        using var request = new HttpRequestMessage(HttpMethod.Post, "/")
+        using var request = new HttpRequestMessage(HttpMethod.Put, $"/{Uri.EscapeDataString(scanId)}")
         {
             Content = new StringContent(
-                JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json"),
+                JsonSerializer.Serialize(data), Encoding.UTF8, "application/json"),
         };
         AddPerRequestHeaders(request, scanId, scanExecutionId);
 
@@ -151,20 +212,7 @@ public sealed class ConnectorStateClient
             if (!response.IsSuccessStatusCode)
             {
                 throw new StateStorageException(
-                    $"connector-state POST returned {(int)response.StatusCode}");
-            }
-
-            var body = await response.Content.ReadAsStringAsync(ct);
-            if (!string.IsNullOrWhiteSpace(body))
-            {
-                using var doc = JsonDocument.Parse(body);
-                var root = doc.RootElement;
-                if (root.TryGetProperty("success", out var successProp) && !successProp.GetBoolean())
-                {
-                    var error = root.TryGetProperty("error", out var errProp)
-                        ? errProp.GetString() : "Unknown error";
-                    throw new StateStorageException($"connector-state POST failed: {error}");
-                }
+                    $"connector-state PUT returned {(int)response.StatusCode}");
             }
         }
         catch (OperationCanceledException)
@@ -181,16 +229,14 @@ public sealed class ConnectorStateClient
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "connector-state POST failed for scan {ScanId}", scanId);
-            throw new StateStorageException($"connector-state POST failed for scan {scanId}", ex);
+            _logger.LogError(ex, "connector-state PUT failed for scan {ScanId}", scanId);
+            throw new StateStorageException($"connector-state PUT failed for scan {scanId}", ex);
         }
     }
 
     /// <summary>
-    /// Deletes all <paramref name="names"/> from the connector-state service, automatically
-    /// splitting into URL-length-bounded batches to avoid <see cref="UriFormatException"/>
-    /// when key count or key length would produce a query string exceeding
-    /// <see cref="MaxDeleteQueryLength"/> characters.
+    /// Deletes all <paramref name="names"/> from the connector-state service for
+    /// <paramref name="scanId"/>.
     /// </summary>
     /// <param name="scanId">The scan whose state keys should be deleted.</param>
     /// <param name="scanExecutionId">Optional execution ID forwarded as a request header for tracing.</param>
@@ -199,67 +245,25 @@ public sealed class ConnectorStateClient
     public async Task DeleteManyAsync(
         string scanId, string? scanExecutionId, string[] names, CancellationToken ct)
     {
-        var baseQs = $"?scanId={Uri.EscapeDataString(scanId)}";
-        var sb = new StringBuilder();
+        if (names.Length == 0)
+            return;
 
-        var i = 0;
-        while (i < names.Length)
+        using var request = new HttpRequestMessage(
+            HttpMethod.Delete, $"/{Uri.EscapeDataString(scanId)}/keys")
         {
-            sb.Clear();
-            sb.Append(baseQs);
-            var batchStart = i;
-
-            while (i < names.Length)
-            {
-                var escaped = $"&name={Uri.EscapeDataString(names[i])}";
-                // If adding this key would exceed the limit AND we already have at least one key
-                // in the batch, flush now. A single key that is longer than the limit is sent
-                // alone (can't split further).
-                if (sb.Length + escaped.Length > MaxDeleteQueryLength && i > batchStart)
-                {
-                    break;
-                }
-
-                sb.Append(escaped);
-                i++;
-            }
-
-            _logger.LogDebug(
-                "Deleting state keys {Start}–{End} of {Total} for scan {ScanId}",
-                batchStart, i - 1, names.Length, scanId);
-
-            await SendDeleteAsync(scanId, scanExecutionId, sb.ToString(), ct);
-        }
-    }
-
-    // ── Private HTTP helpers ─────────────────────────────────────────────────
-
-    private async Task SendDeleteAsync(
-        string scanId, string? scanExecutionId, string queryString, CancellationToken ct)
-    {
-        using var request = new HttpRequestMessage(HttpMethod.Delete, queryString);
+            Content = new StringContent(
+                JsonSerializer.Serialize(names), Encoding.UTF8, "application/json"),
+        };
         AddPerRequestHeaders(request, scanId, scanExecutionId);
 
         try
         {
             using var response = await _client.SendAsync(request, ct);
-            if (!response.IsSuccessStatusCode)
+            if (!response.IsSuccessStatusCode &&
+                response.StatusCode != System.Net.HttpStatusCode.NotFound)
             {
                 throw new StateStorageException(
                     $"connector-state DELETE returned {(int)response.StatusCode}");
-            }
-
-            var body = await response.Content.ReadAsStringAsync(ct);
-            if (!string.IsNullOrWhiteSpace(body))
-            {
-                using var doc = JsonDocument.Parse(body);
-                var root = doc.RootElement;
-                if (root.TryGetProperty("success", out var successProp) && !successProp.GetBoolean())
-                {
-                    var error = root.TryGetProperty("error", out var errProp)
-                        ? errProp.GetString() : "Unknown error";
-                    throw new StateStorageException($"connector-state DELETE failed: {error}");
-                }
             }
         }
         catch (OperationCanceledException)

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorStateStorage.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorStateStorage.cs
@@ -126,18 +126,7 @@ public sealed class ConnectorStateStorage : IStateStorage
             return;
         }
 
-        var allState = await FetchAllStateAsync(cancellationToken);
-
-        var toDelete = allState.Keys
-            .Where(k => MatchesPrefix(k, keyPrefix))
-            .ToArray();
-
-        if (toDelete.Length == 0)
-        {
-            return;
-        }
-
-        await DeleteStateAsync(toDelete, cancellationToken);
+        await _stateClient.DeleteByPrefixAsync(_scanId!, _scanExecutionId, keyPrefix, cancellationToken);
     }
 
     public IAsyncEnumerable<string> ListAllKeysAsync(string keyPrefix = "", CancellationToken cancellationToken = default)
@@ -197,9 +186,6 @@ public sealed class ConnectorStateStorage : IStateStorage
     }
 
     // ── HTTP helpers ─────────────────────────────────────────────────────────
-
-    private Task<Dictionary<string, string>> FetchAllStateAsync(CancellationToken ct)
-        => _stateClient.GetStateAsync(_scanId!, _scanExecutionId, ct);
 
     private Task WriteStateAsync(Dictionary<string, string> data, CancellationToken ct)
         => _stateClient.PutStateAsync(_scanId!, _scanExecutionId, data, ct);

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorStateStorage.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorStateStorage.cs
@@ -188,7 +188,7 @@ public sealed class ConnectorStateStorage : IStateStorage
     // ── HTTP helpers ─────────────────────────────────────────────────────────
 
     private Task WriteStateAsync(Dictionary<string, string> data, CancellationToken ct)
-        => _stateClient.PutStateAsync(_scanId!, _scanExecutionId, data, ct);
+        => _stateClient.PostStateAsync(_scanId!, _scanExecutionId, data, ct);
 
     private Task DeleteStateAsync(string[] names, CancellationToken ct)
         => _stateClient.DeleteManyAsync(_scanId!, _scanExecutionId, names, ct);

--- a/template/netwrix-csharp/ConnectorFramework/ConnectorStateStorage.cs
+++ b/template/netwrix-csharp/ConnectorFramework/ConnectorStateStorage.cs
@@ -167,9 +167,9 @@ public sealed class ConnectorStateStorage : IStateStorage
             yield break;
         }
 
-        var allState = await FetchAllStateAsync(cancellationToken);
+        var allKeys = await _stateClient.ListKeysAsync(_scanId!, _scanExecutionId, cancellationToken);
 
-        foreach (var key in allState.Keys
+        foreach (var key in allKeys
             .Where(k => MatchesPrefix(k, keyPrefix))
             .Order(StringComparer.Ordinal))
         {
@@ -202,7 +202,7 @@ public sealed class ConnectorStateStorage : IStateStorage
         => _stateClient.GetStateAsync(_scanId!, _scanExecutionId, ct);
 
     private Task WriteStateAsync(Dictionary<string, string> data, CancellationToken ct)
-        => _stateClient.PostStateAsync(_scanId!, _scanExecutionId, data, ct);
+        => _stateClient.PutStateAsync(_scanId!, _scanExecutionId, data, ct);
 
     private Task DeleteStateAsync(string[] names, CancellationToken ct)
         => _stateClient.DeleteManyAsync(_scanId!, _scanExecutionId, names, ct);

--- a/template/netwrix-internal-python/index.py
+++ b/template/netwrix-internal-python/index.py
@@ -787,7 +787,7 @@ def run_as_job():
 def run_as_http_server():
     """Start Flask HTTP server for http mode."""
     port = os.getenv("PORT", 5000)
-    serve(app, host="0.0.0.0", port=port)
+    serve(app, host="0.0.0.0", port=port, max_request_body_size=10 * 1024 * 1024 * 1024)  # 10GB
 
 
 def main():

--- a/template/netwrix-internal-python/index.py
+++ b/template/netwrix-internal-python/index.py
@@ -230,25 +230,24 @@ class Context:
         if not self.scan_id:
             raise ValueError("scan_id must be set to retrieve connector state")
 
-        headers = {"Content-Type": "application/json", **self.get_caller_headers()}
+        headers = {**self.get_caller_headers()}
 
         service_name = os.getenv("CONNECTOR_STATE_FUNCTION", "connector-state")
         url = get_service_url(service_name)
 
         response = requests.get(
-            url,
-            params={"scanId": self.scan_id},
+            f"{url}/{self.scan_id}",
             headers=headers,
             timeout=30,
         )
 
         if response.status_code == 200:
             result = response.json()
-            if result.get("success"):
-                self.log.info("Retrieved connector state successfully", key_count=len(result.get("data", {})))
-                return result.get("data", {})
-            error_msg = f"Failed to retrieve connector state: {result.get('error', 'Unknown error')}"
-            raise Exception(error_msg)
+            self.log.info("Retrieved connector state successfully", key_count=len(result))
+            return result
+
+        if response.status_code == 404:
+            return {}
 
         error_msg = f"Status {response.status_code}: {response.text}"
         raise Exception(error_msg)
@@ -273,27 +272,21 @@ class Context:
             raise ValueError("data must be a dictionary")
 
         try:
-            payload = {"scanId": self.scan_id, "data": data}
-
             headers = {"Content-Type": "application/json", **self.get_caller_headers()}
 
             service_name = os.getenv("CONNECTOR_STATE_FUNCTION", "connector-state")
             url = get_service_url(service_name)
 
-            response = requests.post(
-                url,
-                json=payload,
+            response = requests.put(
+                f"{url}/{self.scan_id}",
+                json=data,
                 headers=headers,
                 timeout=30,
             )
 
             if response.status_code == 200:
-                result = response.json()
-                if result.get("success"):
-                    self.log.info("Saved connector state successfully", key_count=len(data))
-                    return True, None
-                error_msg = f"Failed to save connector state: {result.get('error', 'Unknown error')}"
-                return False, error_msg
+                self.log.info("Saved connector state successfully", key_count=len(data))
+                return True, None
 
             error_msg = f"Status {response.status_code}: {response.text}"
             return False, error_msg
@@ -318,33 +311,32 @@ class Context:
             raise ValueError("scan_id must be set to delete connector state")
 
         try:
-            params: dict[str, str | list[str]] = {"scanId": self.scan_id}
-            if names:
-                params["name"] = names
-
-            headers = {"Content-Type": "application/json", **self.get_caller_headers()}
-
             service_name = os.getenv("CONNECTOR_STATE_FUNCTION", "connector-state")
             url = get_service_url(service_name)
+            headers = {**self.get_caller_headers()}
 
-            response = requests.delete(
-                url,
-                params=params,
-                headers=headers,
-                timeout=30,
-            )
+            if names:
+                headers["Content-Type"] = "application/json"
+                response = requests.delete(
+                    f"{url}/{self.scan_id}/keys",
+                    json=names,
+                    headers=headers,
+                    timeout=30,
+                )
+            else:
+                response = requests.delete(
+                    f"{url}/{self.scan_id}",
+                    headers=headers,
+                    timeout=30,
+                )
 
-            if response.status_code == 200:
-                result = response.json()
-                if result.get("success"):
-                    log_attrs = {}
-                    if names:
-                        log_attrs["deleted_names"] = names
-                        log_attrs["deleted_count"] = len(names)
-                    self.log.info("Deleted connector state successfully", **log_attrs)
-                    return True, None
-                error_msg = f"Failed to delete connector state: {result.get('error', 'Unknown error')}"
-                return False, error_msg
+            if response.status_code in (200, 404):
+                log_attrs = {}
+                if names:
+                    log_attrs["deleted_names"] = names
+                    log_attrs["deleted_count"] = len(names)
+                self.log.info("Deleted connector state successfully", **log_attrs)
+                return True, None
 
             error_msg = f"Status {response.status_code}: {response.text}"
             return False, error_msg

--- a/template/netwrix-internal-python/index.py
+++ b/template/netwrix-internal-python/index.py
@@ -165,21 +165,34 @@ from function import handler  # noqa: E402
 
 class Event:
     def __init__(self, execution_mode: str = "http"):
+        self._execution_mode = execution_mode
+        self._body = None
         if execution_mode == "http":
-            # Http mode: read from Flask request
-            self.body = request.get_data()
             self.headers = request.headers
             self.method = request.method
             self.query = request.args
             self.path = request.path
         else:
             # Job mode: read from REQUEST_DATA environment variable (equivalent to HTTP POST body)
-            request_data = os.getenv("REQUEST_DATA", "{}")
-            self.body = request_data.encode()
+            self._body = os.getenv("REQUEST_DATA", "{}").encode()
             self.headers = {}
             self.method = "POST"
             self.query = {}
             self.path = "/"
+
+    @property
+    def body(self):
+        if self._body is None:
+            self._body = request.get_data()
+        return self._body
+
+    @property
+    def stream(self):
+        if self._body is not None:
+            raise RuntimeError("Cannot access stream after body has been read")
+        if self._execution_mode != "http":
+            raise RuntimeError("Stream is only available in http mode")
+        return request.stream
 
 
 class Context:
@@ -260,16 +273,19 @@ class Context:
             raise ValueError("data must be a dictionary")
 
         try:
-            payload = {"scanId": self.scan_id, "data": data}
-
-            headers = {"Content-Type": "application/json", **self.get_caller_headers()}
+            headers = {**self.get_caller_headers()}
 
             service_name = os.getenv("CONNECTOR_STATE_FUNCTION", "connector-state")
             url = get_service_url(service_name)
 
+            # Send as multipart form: each key-value pair is a part,
+            # scanId is a query parameter.
+            files = {name: (None, str(value) if value is not None else "") for name, value in data.items()}
+
             response = requests.post(
                 url,
-                json=payload,
+                params={"scanId": self.scan_id},
+                files=files,
                 headers=headers,
                 timeout=30,
             )

--- a/template/netwrix-internal-python/index.py
+++ b/template/netwrix-internal-python/index.py
@@ -271,6 +271,10 @@ class Context:
         if not isinstance(data, dict):
             raise ValueError("data must be a dictionary")
 
+        for key, value in data.items():
+            if not isinstance(value, str):
+                raise ValueError(f"All values must be strings; got {type(value).__name__} for key '{key}'")
+
         try:
             headers = {"Content-Type": "application/json", **self.get_caller_headers()}
 

--- a/template/netwrix-internal-python/index.py
+++ b/template/netwrix-internal-python/index.py
@@ -273,19 +273,16 @@ class Context:
             raise ValueError("data must be a dictionary")
 
         try:
-            headers = {**self.get_caller_headers()}
+            payload = {"scanId": self.scan_id, "data": data}
+
+            headers = {"Content-Type": "application/json", **self.get_caller_headers()}
 
             service_name = os.getenv("CONNECTOR_STATE_FUNCTION", "connector-state")
             url = get_service_url(service_name)
 
-            # Send as multipart form: each key-value pair is a part,
-            # scanId is a query parameter.
-            files = {name: (None, str(value) if value is not None else "") for name, value in data.items()}
-
             response = requests.post(
                 url,
-                params={"scanId": self.scan_id},
-                files=files,
+                json=payload,
                 headers=headers,
                 timeout=30,
             )

--- a/template/netwrix-python/index.py
+++ b/template/netwrix-python/index.py
@@ -479,6 +479,10 @@ class Context:
         if not isinstance(data, dict):
             raise ValueError("data must be a dictionary")
 
+        for key, value in data.items():
+            if not isinstance(value, str):
+                raise ValueError(f"All values must be strings; got {type(value).__name__} for key '{key}'")
+
         try:
             headers = {"Content-Type": "application/json", **self.get_caller_headers()}
 

--- a/template/netwrix-python/index.py
+++ b/template/netwrix-python/index.py
@@ -388,27 +388,24 @@ class Context:
         if not self.scan_id:
             raise ValueError("scan_id must be set to retrieve connector state")
 
-        # Build headers with caller context information
-        headers = {"Content-Type": "application/json", **self.get_caller_headers()}
+        headers = {**self.get_caller_headers()}
 
-        # Get service URL for connector-state
         service_name = os.getenv("CONNECTOR_STATE_FUNCTION", "connector-state")
         url = get_service_url(service_name)
 
         response = requests.get(
-            url,
-            params={"scanId": self.scan_id},
+            f"{url}/{self.scan_id}",
             headers=headers,
             timeout=30,
         )
 
         if response.status_code == 200:
             result = response.json()
-            if result.get("success"):
-                self.log.info("Retrieved connector state successfully", key_count=len(result.get("data", {})))
-                return result.get("data", {})
-            error_msg = f"Failed to retrieve connector state: {result.get('error', 'Unknown error')}"
-            raise Exception(error_msg)
+            self.log.info("Retrieved connector state successfully", key_count=len(result))
+            return result
+
+        if response.status_code == 404:
+            return {}
 
         error_msg = f"Status {response.status_code}: {response.text}"
         raise Exception(error_msg)
@@ -430,37 +427,32 @@ class Context:
             raise ValueError("scan_id must be set to delete connector state")
 
         try:
-            # Build params with scanId and optional name parameters
-            params: dict[str, str | list[str]] = {"scanId": self.scan_id}
-            if names:
-                # Add multiple name parameters to the query string
-                params["name"] = names
-
-            # Build headers with caller context information
-            headers = {"Content-Type": "application/json", **self.get_caller_headers()}
-
-            # Get service URL for connector-state
             service_name = os.getenv("CONNECTOR_STATE_FUNCTION", "connector-state")
             url = get_service_url(service_name)
+            headers = {**self.get_caller_headers()}
 
-            response = requests.delete(
-                url,
-                params=params,
-                headers=headers,
-                timeout=30,
-            )
+            if names:
+                headers["Content-Type"] = "application/json"
+                response = requests.delete(
+                    f"{url}/{self.scan_id}/keys",
+                    json=names,
+                    headers=headers,
+                    timeout=30,
+                )
+            else:
+                response = requests.delete(
+                    f"{url}/{self.scan_id}",
+                    headers=headers,
+                    timeout=30,
+                )
 
-            if response.status_code == 200:
-                result = response.json()
-                if result.get("success"):
-                    log_attrs = {}
-                    if names:
-                        log_attrs["deleted_names"] = names
-                        log_attrs["deleted_count"] = len(names)
-                    self.log.info("Deleted connector state successfully", **log_attrs)
-                    return True, None
-                error_msg = f"Failed to delete connector state: {result.get('error', 'Unknown error')}"
-                return False, error_msg
+            if response.status_code in (200, 404):
+                log_attrs = {}
+                if names:
+                    log_attrs["deleted_names"] = names
+                    log_attrs["deleted_count"] = len(names)
+                self.log.info("Deleted connector state successfully", **log_attrs)
+                return True, None
 
             error_msg = f"Status {response.status_code}: {response.text}"
             return False, error_msg
@@ -488,29 +480,21 @@ class Context:
             raise ValueError("data must be a dictionary")
 
         try:
-            payload = {"scanId": self.scan_id, "data": data}
-
-            # Build headers with caller context information
             headers = {"Content-Type": "application/json", **self.get_caller_headers()}
 
-            # Get service URL for connector-state
             service_name = os.getenv("CONNECTOR_STATE_FUNCTION", "connector-state")
             url = get_service_url(service_name)
 
-            response = requests.post(
-                url,
-                json=payload,
+            response = requests.put(
+                f"{url}/{self.scan_id}",
+                json=data,
                 headers=headers,
                 timeout=30,
             )
 
             if response.status_code == 200:
-                result = response.json()
-                if result.get("success"):
-                    self.log.info("Saved connector state successfully", key_count=len(data))
-                    return True, None
-                error_msg = f"Failed to save connector state: {result.get('error', 'Unknown error')}"
-                return False, error_msg
+                self.log.info("Saved connector state successfully", key_count=len(data))
+                return True, None
 
             error_msg = f"Status {response.status_code}: {response.text}"
             return False, error_msg

--- a/template/netwrix-python/index.py
+++ b/template/netwrix-python/index.py
@@ -300,21 +300,34 @@ class BatchManager:
 
 class Event:
     def __init__(self, execution_mode: str = "http"):
+        self._execution_mode = execution_mode
+        self._body = None
         if execution_mode == "http":
-            # HTTP mode: read from Flask request
-            self.body = request.get_data()
             self.headers = request.headers
             self.method = request.method
             self.query = request.args
             self.path = request.path
         else:
             # Job mode: read from REQUEST_DATA environment variable (equivalent to HTTP POST body)
-            request_data = os.getenv("REQUEST_DATA", "{}")
-            self.body = request_data.encode()
+            self._body = os.getenv("REQUEST_DATA", "{}").encode()
             self.headers = {}
             self.method = "POST"
             self.query = {}
             self.path = "/"
+
+    @property
+    def body(self):
+        if self._body is None:
+            self._body = request.get_data()
+        return self._body
+
+    @property
+    def stream(self):
+        if self._body is not None:
+            raise RuntimeError("Cannot access stream after body has been read")
+        if self._execution_mode != "http":
+            raise RuntimeError("Stream is only available in http mode")
+        return request.stream
 
 
 class Context:


### PR DESCRIPTION
Update Python and C# connector templates to use the redesigned connector-state                                                                         
  HTTP API: path-based routes (/{scanId}, /{scanId}/keys, /{scanId}/keys/{key}),
  flat JSON dict responses, JSON-array body deletes, and prefix-based bulk deletion.                                                                     
                                                                                                                                                         
  Python templates (netwrix-python, netwrix-internal-python):
  - get_connector_state: GET /{scanId}/keys/{key}, 404 treated as not found                                                                              
  - set_connector_state: POST /{scanId} with flat dict; raises ValueError if any                                                                         
    value is not a string
  - delete_connector_state: DELETE /{scanId} (all) or DELETE /{scanId}/keys with                                                                         
    JSON array body (specific keys); 404 treated as success                                                                                              
  - Event.body is now a lazy property; Event.stream exposes the raw request stream                                                                       
                                                                                                                                                         
  C# ConnectorStateClient:                                                                                                                               
  - Replace OpenStateDocumentAsync/SendDeleteAsync with typed methods: GetStateAsync,                                                                    
    ListKeysAsync, GetStateValueAsync, PostStateAsync, DeleteManyAsync, DeleteByPrefixAsync                                                            
  - Remove MaxDeleteQueryLength and URL-length-based delete batching                                                                                     
   
  C# ConnectorStateStorage:                                                                                                                              
  - ListAllKeysCoreAsync now calls GET /{scanId}/keys directly                                                                                         
  - DeleteAllAsync delegates to DeleteByPrefixAsync (no GET-then-delete round trip)                                                                      
   
  Tests: updated ConnectorStateStorageTests and ResilienceRegistrationTests for the                                                                      
  new response formats; added ConnectorStateClientRouteTests (merged into                                                                              
  ConnectorFramework.Tests, replacing the standalone RouteTests project).