### PR TITLE
Register handler-specific OTel meters via wildcard + document the convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Both the `netwrix-csharp` and `netwrix-python` templates include a `BatchManager
 
 All templates export distributed traces, metrics, and logs to an OTLP-compatible collector. Configure the endpoint via `OTEL_EXPORTER_OTLP_ENDPOINT` (default: `http://otel-collector.access-analyzer.svc.cluster.local:4318`). Set `OTEL_ENABLED=false` to disable.
 
+Framework-level metrics (batch sizes, object upload counts, execution duration, process resources) are emitted by `ConnectorFramework/ConnectorMetrics.cs` under the meter `Netwrix.ConnectorFramework`. Handler-specific metrics belong in the connector assembly under a meter named `Netwrix.Connectors.<Source>.<Handler>`; the C# template's `Program.cs` registers that prefix via a wildcard so no template edit is needed per handler. See [`template/netwrix-csharp/README.md` § Custom metrics](template/netwrix-csharp/README.md#custom-metrics) for the convention and the static-class pattern.
+
 ### Secrets
 
 Secrets are loaded from files mounted at `/var/secrets/{name}`. Access them via `context.Secrets["name"]` (C#) or `context.secrets["name"]` (Python).

--- a/template/netwrix-csharp/ConnectorFramework/Program.cs
+++ b/template/netwrix-csharp/ConnectorFramework/Program.cs
@@ -445,6 +445,11 @@ internal static class Program
                 metrics.SetResourceBuilder(resourceBuilder)
                     .AddMeter(ConnectorMetrics.MeterName)
                     .AddMeter("Netwrix.Overlord.Sdk.Orchestration") // CrawlRunOrchestratorMetrics.MeterName — use type constant once Sdk.Orchestration package is bumped
+                    // Handler-specific meters defined in connector assemblies. The convention is
+                    // Meter("Netwrix.Connectors.<Source>.<Handler>") — see netwrix-csharp/README.md
+                    // § Custom metrics. The wildcard avoids touching this file for every new handler
+                    // that wants its own instruments; framework-level meters stay enumerated above.
+                    .AddMeter("Netwrix.Connectors.*")
                     .AddHttpClientInstrumentation();
 
                 if (isHttpMode)

--- a/template/netwrix-csharp/README.md
+++ b/template/netwrix-csharp/README.md
@@ -246,6 +246,58 @@ services.AddScoped(_ => new SupportedStates(Stop: true, Pause: true, Resume: tru
 
 ---
 
+## Custom metrics
+
+The framework already emits a baseline set of OTel metrics through `ConnectorFramework/ConnectorMetrics.cs` (`connector.execution.duration`, `connector.objects.uploaded`, `connector.batch.size`, `connector.tasks.*`, `connector.source.rate_limits`, plus `process.*` gauges). Resource attributes (`scan_execution_id`, `scan_id`, `source_id`, `deployment.environment`, `service.version`) are attached to every export by `Program.cs`, so handler-defined metrics inherit them automatically.
+
+When a handler needs metrics that are specific to its own work (calculator durations, per-source read counters, domain-specific error categories), define them in the connector assembly — **do not** extend `ConnectorMetrics` for handler-specific semantics. The framework registers handler meters via a wildcard, so no edit to `Program.cs` is required.
+
+### Naming convention
+
+| Element | Convention | Example |
+|---|---|---|
+| `Meter` name | `Netwrix.Connectors.<Source>.<Handler>` | `Netwrix.Connectors.SharePointOnline.EffectivePermissions` |
+| Instrument name | dotted lowercase; either the framework `connector.*` namespace for cross-handler semantics or a handler-specific prefix for domain metrics | `effective_permissions.calculator.duration`, `connector.objects.uploaded` |
+| Unit | [UCUM](https://ucum.org/ucum) | `s`, `By`, `{items}`, `{rows}` |
+| Tags | low-cardinality dimensions only (table, kind, error category) — never per-object IDs | `kind=objects\|aces\|principals`, `error=calculator` |
+
+The `Program.cs` wildcard `AddMeter("Netwrix.Connectors.*")` picks up any meter whose name matches that prefix. Drift outside the prefix means the meter is silently dropped at export — there is no build-time check.
+
+### Pattern
+
+```csharp
+// connectors/.../my-handler/MyHandlerMetrics.cs
+using System.Diagnostics.Metrics;
+
+namespace Netwrix.Connector.MyHandler;
+
+internal static class MyHandlerMetrics
+{
+    public const string MeterName = "Netwrix.Connectors.MySource.MyHandler";
+    private static readonly Meter Meter = new(MeterName, "1.0");
+
+    public static readonly Histogram<double> WorkDuration = Meter.CreateHistogram<double>(
+        "my_handler.work.duration",
+        unit: "s",
+        description: "Wall-clock time spent doing the unit of work this handler owns");
+
+    public static readonly Counter<long> RowsRead = Meter.CreateCounter<long>(
+        "my_handler.rows.read",
+        unit: "{rows}",
+        description: "Rows read from the source, tagged with `kind`");
+
+    public static readonly Counter<long> Errors = Meter.CreateCounter<long>(
+        "my_handler.errors",
+        description: "Handler errors, tagged with `kind` (e.g. transport, schema, business-rule)");
+}
+```
+
+Use the instruments anywhere in the handler — `MyHandlerMetrics.RowsRead.Add(1, new KeyValuePair<string, object?>("kind", "objects"))`. No DI wiring is required because the `Meter` is a static field.
+
+See `ConnectorFramework/ConnectorMetrics.cs` for the framework's own static-class layout (counters, histograms, observable gauges in a single static constructor) as a reference implementation.
+
+---
+
 ## Environment variables
 
 | Variable | Default | Description |


### PR DESCRIPTION
## Summary

- `template/netwrix-csharp/ConnectorFramework/Program.cs`: add `.AddMeter("Netwrix.Connectors.*")` next to the existing explicit framework meter registrations. Lets connector handlers define their own `System.Diagnostics.Metrics.Meter` instances without editing this file per handler.
- `template/netwrix-csharp/README.md`: new `## Custom metrics` section — naming convention (`Netwrix.Connectors.<Source>.<Handler>`), instrument naming/unit/tag rules (dotted lowercase, UCUM units, low-cardinality tags), and a static-class pattern modelled on `ConnectorMetrics.cs`.
- `README.md` (top-level): one-paragraph cross-link from the OpenTelemetry blurb to the new section.

## Why

Today the metrics whitelist in `Program.cs` is hand-rolled with explicit meter names. Any meter defined inside a connector assembly (i.e. outside `ConnectorFramework`) is silently dropped at export — the resource attributes (`scan_execution_id`, `scan_id`, `source_id`) are wired correctly, but the meter never reaches the OTLP exporter.

Driven by **WI #439887** — the SPO effective-permissions handler ([feature #414235](https://dev.azure.com/NetwrixCorporation/MSP%20Cloud%20Security/_workitems/edit/414235)) is the first handler that needs its own instruments (calculator duration, per-source read counters with `kind` tag, domain error categories, distinct-principals counter) beyond the framework's baseline. Hard-coding each new handler's meter name in the shared `Program.cs` would (a) drift this file with source-specific names, and (b) silently break the next time someone forgets to register one. The wildcard plus a documented convention turns "new handler with metrics" back into a single-repo change.

## Verification

- `dotnet build template/netwrix-csharp/ConnectorFramework/ConnectorFramework.csproj -c Release` → 0 warnings / 0 errors (full solution build fails on a pre-existing stale `Function.csproj` reference removed in #90, unrelated).
- OpenTelemetry .NET SDK 1.15.* (the version pinned in `ConnectorFramework.csproj`) supports `*` wildcards in `MeterProviderBuilder.AddMeter`.
- Functional verification will land with the consumer PR in `netwrix-dev/dspm-connectors` (handler-side E1 — emits `effective_permissions.*` instruments and verifies they appear in the local otel-collector debug exporter).

## Test plan

- [x] `dotnet build` clean (Release, ConnectorFramework)
- [ ] Reviewers: confirm the convention name (`Netwrix.Connectors.<Source>.<Handler>`) is acceptable as the project-wide standard
- [ ] After merge: bump vendored template snapshot in `dspm-connectors` via `make templates-update` and land the E1 consumer PR

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>