### PR TITLE
ci: self-managed dependency submission with ADO NuGet auth

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -15,6 +15,10 @@ name: Dependency submission
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/dependency-submission.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -57,4 +57,4 @@ jobs:
             --store-password-in-clear-text
 
       - name: Submit dependency graph (NuGet + Python)
-        uses: advanced-security/component-detection-dependency-submission-action@v0
+        uses: advanced-security/component-detection-dependency-submission-action@v0.1.3

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,56 @@
+name: Dependency submission
+
+# Self-managed replacement for GitHub's "Automatic dependency submission"
+# (dynamic/dependency-graph/auto-submission), which cannot authenticate against
+# the Azure DevOps NuGet feeds this repo's C# templates depend on. The auto
+# workflow has been failing on every run with NU1301 401 Unauthorized since at
+# least 2025-12 — see PR #94 thread for context.
+#
+# This workflow restores NuGet sources with credentials and then invokes
+# GitHub's component detection action to submit the full dependency graph
+# (NuGet + Python). After this lands, disable the automatic submission toggle
+# at Settings → Code security → Automatic dependency submission to avoid two
+# workflows fighting over the same Dependency Graph endpoint.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Authenticate against Netwrix ADO NuGet feeds
+        env:
+          NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
+        run: |
+          # Both private feeds use the same PAT. --store-password-in-clear-text
+          # is required on Linux (no Windows credential manager). The token
+          # lives only on the runner for the duration of the job.
+          dotnet nuget add source \
+            "https://pkgs.dev.azure.com/NetwrixCorporation/_packaging/Netwrix.UK%40Local/nuget/v3/index.json" \
+            --name Netwrix.UK \
+            --username unused \
+            --password "$NUGET_TOKEN" \
+            --store-password-in-clear-text
+          dotnet nuget add source \
+            "https://pkgs.dev.azure.com/NetwrixCorporation/NetwrixAuditor/_packaging/Netwrix.Auditor/nuget/v3/index.json" \
+            --name Netwrix.Auditor \
+            --username unused \
+            --password "$NUGET_TOKEN" \
+            --store-password-in-clear-text
+
+      - name: Submit dependency graph (NuGet + Python)
+        uses: advanced-security/component-detection-dependency-submission-action@v0


### PR DESCRIPTION
## Summary

Replaces GitHub's auto-managed `Automatic dependency submission` workflow with a self-managed one that authenticates against the Azure DevOps NuGet feeds before invoking the component-detection action. Uses the newly provisioned `NUGET_TOKEN` repo secret.

## Why

Per the thread on #94, the auto-managed workflow (`dynamic/dependency-graph/auto-submission`) has been failing on **every** run since at least 2025-12 — 88 of the last 89 runs landed `NU1301 401 Unauthorized` against `pkgs.dev.azure.com/NetwrixCorporation/_packaging/Netwrix.UK@Local/...` and `.../NetwrixAuditor/_packaging/Netwrix.Auditor/...`. Symptoms:

- Every PR opens with a red `submit-nuget` check, which trains reviewers to merge over red.
- The C# dependency graph for the template is stale, so Dependabot alerts on .NET packages do not fire.
- Anyone who later adds a required-check rule blocks the repo.

The auto workflow is generated by GitHub from a fixed recipe and has no slot to inject credentials for private feeds, so the only path forward is self-managing the workflow. `NUGET_TOKEN` was provisioned at repo scope today (Vlad).

## Changes

- `.github/workflows/dependency-submission.yml` — new. Sets up .NET 8, adds the two ADO feeds with `dotnet nuget add source --password ${{ secrets.NUGET_TOKEN }} --store-password-in-clear-text`, then runs `advanced-security/component-detection-dependency-submission-action@v0` to submit the merged graph (NuGet + Python).

The action is the same one GitHub's auto-workflow invokes under the hood, so the resulting graph shape stays identical — just with credentials available this time.

## Follow-up after merge

Flip **Settings → Code security and analysis → Automatic dependency submission** to **off** so both workflows do not race over the Dependency Graph endpoint. Cannot do that in code from this PR — needs repo Admin. I'll ping in chat once this is merged.

## Test plan

- [ ] CI: the new `Dependency submission / submit` job runs on this PR (push-triggered, so it'll run when the branch updates) — confirm green.
- [ ] After merge: confirm a fresh `main` push produces a green `Dependency submission / submit` and Insights → Dependency graph reflects the C# packages from `template/netwrix-csharp/ConnectorFramework/ConnectorFramework.csproj`.
- [ ] After the auto-submission toggle is flipped off: the `submit-nuget` check disappears from PRs.

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>